### PR TITLE
fix: remove default value for tests

### DIFF
--- a/src/commands/deploy/metadata.ts
+++ b/src/commands/deploy/metadata.ts
@@ -79,7 +79,6 @@ export default class DeployMetadata extends SfCommand<DeployMetadataResult> {
       multiple: true,
       summary: messages.getMessage('flags.tests.summary'),
       description: messages.getMessage('flags.tests.description'),
-      default: [],
     }),
     'test-level': testLevelFlag({
       default: TestLevel.NoTestRun,


### PR DESCRIPTION
### What does this PR do?

remove unnecessary default value for the `--tests` flag

### What issues does this PR fix or reference?
[skip-validate-pr]