### PR TITLE
Sm/external nuts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ parameters:
     default: ''
     type: string
   repo_tag:
-    description: 'The tag of the module repo to checkout, '''' defaults to branch/PR'
+    description: "The tag of the module repo to checkout, '' defaults to branch/PR"
     default: ''
     type: string
 workflows:
@@ -52,16 +52,21 @@ workflows:
                 - lts
                 - maintenance
       - release-management/test-nut:
-          name: nuts-on-linux
           sfdx_version: latest
           requires:
             - release-management/test-package
-      - release-management/test-nut:
-          name: nuts-on-windows
-          sfdx_version: latest
-          os: windows
-          requires:
-            - release-management/test-package
+          size: xlarge
+          matrix:
+            parameters:
+              os: [windows, linux]
+              command:
+                [
+                  'yarn test:nuts:deploy:metadata:manifest',
+                  'yarn test:nuts:deploy:metadata:metadata',
+                  'yarn test:nuts:deploy:metadata:source-dir',
+                  'yarn test:nuts:deploy:metadata:test-level',
+                  'yarn test:nuts:static',
+                ]
       - release-management/release-package:
           sign: true
           github-release: true

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "test:nuts:deploy:metadata:metadata": "cross-env PLUGIN_DEPLOY_RETRIEVE_SEED_FILTER=deploy.metadata.metadata ts-node ./test/nuts/generateNuts.ts && mocha \"test/nuts/generated/*.nut.ts\" --slow 4500 --timeout 600000 --parallel --retries 0",
     "test:nuts:deploy:metadata:source-dir": "cross-env PLUGIN_DEPLOY_RETRIEVE_SEED_FILTER=deploy.metadata.source-dir ts-node ./test/nuts/generateNuts.ts && mocha \"test/nuts/generated/*.nut.ts\" --slow 4500 --timeout 600000 --parallel --retries 0",
     "test:nuts:deploy:metadata:test-level": "cross-env PLUGIN_DEPLOY_RETRIEVE_SEED_FILTER=deploy.metadata.test-level ts-node ./test/nuts/generateNuts.ts && mocha \"test/nuts/generated/*.nut.ts\" --slow 4500 --timeout 600000 --parallel --retries 0",
+    "test:nuts:static": "nyc mocha \"test/commands/**/*.nut.ts\"  --slow 4500 --timeout 600000 --parallel --retries 0",
     "version": "oclif readme"
   },
   "publishConfig": {


### PR DESCRIPTION
### What does this PR do?
creates a `nuts:static` to run all the non-generated nuts separately (will be used for external nuts on libraries)
modifies circle to split up the NUTs (for shorter cycle time AND to allow for rerunning individual failed segments)

### What issues does this PR fix or reference?
[@W-10909105@](https://gus.lightning.force.com/a07EE00000to0oUYAQ)