### PR TITLE
chore: update external command executions

### DIFF
--- a/test/nuts/seeds/deploy.metadata.manifest.seed.ts
+++ b/test/nuts/seeds/deploy.metadata.manifest.seed.ts
@@ -45,7 +45,7 @@ context('deploy metadata --manifest NUTs [name: %REPO_NAME%]', () => {
         const paths = testCase.toDeploy.map((t) => path.normalize(t)).join(',');
         // This is using the force:source:convert command from plugin-source. Once we have an
         // sf equivalent, we should switch it to use that.
-        await testkit.convert({ args: `--sourcepath ${paths} --outputdir out` });
+        await testkit.convert({ args: `--sourcepath ${paths} --outputdir out`, cli: 'sfdx' });
         const packageXml = path.join('out', 'package.xml');
 
         const deploy = await testkit.deploy<DeployResultJson>({ args: `--manifest ${packageXml}` });

--- a/test/nuts/seeds/deploy.metadata.metadata-dir.seed.ts
+++ b/test/nuts/seeds/deploy.metadata.metadata-dir.seed.ts
@@ -41,7 +41,7 @@ context('deploy metadata --metadata-dir NUTs [name: %REPO_NAME%]', () => {
         const paths = testCase.toDeploy.map((t) => path.normalize(t)).join(',');
         // This is using the force:source:convert command from plugin-source. Once we have an
         // sf equivalent, we should switch it to use that.
-        await testkit.convert({ args: `--sourcepath ${paths} --outputdir out` });
+        await testkit.convert({ args: `--sourcepath ${paths} --outputdir out`, cli: 'sfdx' });
 
         const deploy = await testkit.deploy<DeployResultJson>({ args: '--metadata-dir out' });
         testkit.expect.toHavePropertyAndValue(deploy.result as unknown as JsonMap, 'status', RequestStatus.Succeeded);

--- a/test/nuts/seeds/deploy.metadata.metadata.seed.ts
+++ b/test/nuts/seeds/deploy.metadata.metadata.seed.ts
@@ -24,7 +24,7 @@ context('deploy metadata --metadata NUTs [name: %REPO_NAME%]', () => {
     const args = testkit.packageNames.map((p) => `--source-dir ${p}`).join(' ');
     await testkit.deploy({ args });
     if (REPO.gitUrl.includes('dreamhouse')) {
-      await testkit.assignPermissionSet({ args: '--permsetname dreamhouse' });
+      await testkit.assignPermissionSet({ args: '--permsetname dreamhouse', cli: 'sfdx' });
     }
   });
 
@@ -54,7 +54,7 @@ context('deploy metadata --metadata NUTs [name: %REPO_NAME%]', () => {
     });
 
     it('should not deploy metadata outside of a package directory', async () => {
-      await testkit.createApexClass({ args: '--outputdir NotAPackage --classname ShouldNotBeDeployed' });
+      await testkit.createApexClass({ args: '--outputdir NotAPackage --classname ShouldNotBeDeployed', cli: 'sfdx' });
       await testkit.deploy({ args: '--metadata ApexClass' });
       // this is a glob, so no need for path.join
       await testkit.expect.filesToNotBeDeployed(['NotAPackage/**/*']);

--- a/test/nuts/seeds/deploy.metadata.test-level.seed.ts
+++ b/test/nuts/seeds/deploy.metadata.test-level.seed.ts
@@ -23,7 +23,7 @@ context('deploy metadata --test-level NUTs [name: %REPO_NAME%]', () => {
     const args = testkit.packageNames.map((p) => `--source-dir ${p}`).join(' ');
     await testkit.deploy({ args });
     if (REPO.gitUrl.includes('dreamhouse')) {
-      await testkit.assignPermissionSet({ args: '--permsetname dreamhouse' });
+      await testkit.assignPermissionSet({ args: '--permsetname dreamhouse', cli: 'sfdx' });
     }
   });
 


### PR DESCRIPTION
### What does this PR do?

Adds `{ cli: 'sfdx' }` to external command executions so that just-nuts will pass

### What issues does this PR fix or reference?
[skip-validate-pr]