### PR TITLE
feat: add --only-ignored flag to 'project deploy preview'

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -14,7 +14,7 @@
   {
     "command": "project:deploy:preview",
     "plugin": "@salesforce/plugin-deploy-retrieve",
-    "flags": ["ignore-conflicts", "json", "manifest", "metadata", "source-dir", "target-org"],
+    "flags": ["ignore-conflicts", "json", "manifest", "metadata", "only-ignored", "source-dir", "target-org"],
     "alias": ["deploy:metadata:preview"]
   },
   {

--- a/messages/deploy.metadata.preview.md
+++ b/messages/deploy.metadata.preview.md
@@ -36,6 +36,10 @@ To preview the deployment of multiple metadata components, either set multiple -
 
 Login username or alias for the target org.
 
+# flags.only-ignored.summary
+
+Preview files to be ignored in a deployment.
+
 # flags.target-org.description
 
 Overrides your default org.

--- a/src/utils/previewOutput.ts
+++ b/src/utils/previewOutput.ts
@@ -243,7 +243,7 @@ const printConflictsTable = (files: PreviewFile[]): void => {
   }
 };
 
-const printIgnoredTable = (files: PreviewFile[], baseOperation: BaseOperation): void => {
+export const printIgnoredTable = (files: PreviewFile[], baseOperation: BaseOperation): void => {
   ux.log();
   if (files.length === 0) {
     ux.log(dim(messages.getMessage('ignored.none')));


### PR DESCRIPTION
### What does this PR do?
adds `--only-ignored` flag to `project deploy preview`
to be used as a replacement for `sfdx force:source:ignored:list`


### What issues does this PR fix or reference?
@W-12566128@