### PR TITLE
feat: take project commands out of beta

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -9,7 +9,7 @@
     "command": "project:convert:mdapi",
     "plugin": "@salesforce/plugin-deploy-retrieve",
     "flags": ["api-version", "json", "loglevel", "manifest", "metadata", "metadata-dir", "output-dir", "root-dir"],
-    "alias": ["force:mdapi:beta:convert", "force:mdapi:convert"]
+    "alias": ["force:mdapi:convert"]
   },
   {
     "command": "project:convert:source",
@@ -51,7 +51,7 @@
     "command": "project:delete:tracking",
     "plugin": "@salesforce/plugin-deploy-retrieve",
     "flags": ["api-version", "json", "loglevel", "no-prompt", "target-org"],
-    "alias": ["force:source:beta:tracking:clear", "force:source:tracking:clear"]
+    "alias": ["force:source:tracking:clear"]
   },
   {
     "command": "project:deploy:cancel",
@@ -181,7 +181,7 @@
     "command": "project:reset:tracking",
     "plugin": "@salesforce/plugin-deploy-retrieve",
     "flags": ["api-version", "json", "loglevel", "no-prompt", "revision", "target-org"],
-    "alias": ["force:source:beta:tracking:reset", "force:source:tracking:reset"]
+    "alias": ["force:source:tracking:reset"]
   },
   {
     "command": "project:retrieve:preview",

--- a/src/commands/project/convert/mdapi.ts
+++ b/src/commands/project/convert/mdapi.ts
@@ -35,7 +35,7 @@ export interface EnsureFsFlagOptions {
   throwOnENOENT?: boolean;
 }
 export class Mdapi extends SfCommand<ConvertMdapiJson> {
-  public static readonly aliases = ['force:mdapi:beta:convert', 'force:mdapi:convert'];
+  public static readonly aliases = ['force:mdapi:convert'];
   public static readonly deprecateAliases = true;
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');

--- a/src/commands/project/delete/tracking.ts
+++ b/src/commands/project/delete/tracking.ts
@@ -25,7 +25,7 @@ export type DeleteTrackingResult = {
 
 export class DeleteTracking extends SfCommand<DeleteTrackingResult> {
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:source:beta:tracking:clear', 'force:source:tracking:clear'];
+  public static readonly aliases = ['force:source:tracking:clear'];
   public static readonly summary = messages.getMessage('deleteSummary');
   public static readonly description = messages.getMessage('deleteDescription');
   public static readonly requiresProject = true;

--- a/src/commands/project/deploy/cancel.ts
+++ b/src/commands/project/deploy/cancel.ts
@@ -23,7 +23,6 @@ export default class DeployMetadataCancel extends SfCommand<DeployResultJson> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['deploy:metadata:cancel'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/preview.ts
+++ b/src/commands/project/deploy/preview.ts
@@ -21,7 +21,6 @@ export default class DeployMetadataPreview extends SfCommand<PreviewResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['deploy:metadata:preview'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -26,7 +26,6 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['deploy:metadata:quick'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -22,7 +22,6 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['deploy:metadata:report'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -25,7 +25,6 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['deploy:metadata:resume'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -30,7 +30,6 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['deploy:metadata'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -28,7 +28,6 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['deploy:metadata:validate'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/reset/tracking.ts
+++ b/src/commands/project/reset/tracking.ts
@@ -26,7 +26,7 @@ export type ResetTrackingResult = {
 
 export class ResetTracking extends SfCommand<ResetTrackingResult> {
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:source:beta:tracking:reset', 'force:source:tracking:reset'];
+  public static readonly aliases = ['force:source:tracking:reset'];
   public static readonly summary = messages.getMessage('resetSummary');
   public static readonly description = messages.getMessage('resetDescription');
   public static readonly requiresProject = true;

--- a/src/commands/project/retrieve/preview.ts
+++ b/src/commands/project/retrieve/preview.ts
@@ -18,7 +18,6 @@ export default class RetrieveMetadataPreview extends SfCommand<PreviewResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['retrieve:metadata:preview'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -31,7 +31,6 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly state = 'beta';
   public static readonly aliases = ['retrieve:metadata'];
   public static readonly deprecateAliases = true;
 


### PR DESCRIPTION
### What does this PR do?
1. take state beta off of project commands
2. remove the beta aliases that came over from plugin-source

### What issues does this PR fix or reference?
