### PR TITLE
fix: replace hardcoded 'sf' with config.bin for sfdx use

### DIFF
--- a/messages/convert.mdapi.md
+++ b/messages/convert.mdapi.md
@@ -8,6 +8,8 @@ To use Salesforce CLI to work with components that you retrieved via Metadata AP
 
 To convert files from the source format back to the metadata format, run "<%= config.bin %> project convert source".
 
+To convert multiple metadata components, either set multiple --metadata <name> flags or a single --metadata flag with multiple names separated by spaces. Enclose names that contain spaces in one set of double quotes. The same syntax applies to --manifest and --source-dir.
+
 # examples
 
 - Convert metadata formatted files in the specified directory into source formatted files; writes converted files to your default package directory:
@@ -32,11 +34,11 @@ File path to manifest (package.xml) of metadata types to convert.
 
 # flags.metadata-dir.summary
 
-Comma-separated list of paths to the local metadata files to convert.
+Root of directory or zip file of metadata formatted files to convert.
 
 # flags.metadata.summary
 
-Comma-separated list of metadata component names to convert.
+Metadata component names to convert.
 
 # flags.manifest.description
 

--- a/messages/convert.source.md
+++ b/messages/convert.source.md
@@ -10,6 +10,8 @@ To convert Metadata API–formatted files into the source format, run "<%= confi
 
 To specify a package name that includes spaces, enclose the name in single quotes.
 
+To convert multiple components, either set multiple --metadata <name> flags or a single --metadata flag with multiple names separated by spaces. Enclose names that contain spaces in one set of double quotes. The same syntax applies to --manifest and --source-dir.
+
 # examples
 
 - Convert source-formatted files in the specified directory into metadata-formatted files; writes converted files into a new directory:
@@ -38,11 +40,11 @@ Path to the manifest (package.xml) file that specifies the metadata types to con
 
 # flags.source-dir.summary
 
-Comma-separated list of paths to the local source files to convert.
+Paths to the local source files to convert.
 
 # flags.metadata.summary
 
-Comma-separated list of metadata component names to convert.
+Metadata component names to convert.
 
 # flags.manifest.description
 

--- a/messages/delete.source.md
+++ b/messages/delete.source.md
@@ -8,6 +8,8 @@ Use this command to delete components from orgs that don’t have source trackin
 
 When you run this command, both the local source file and the metadata component in the org are deleted.
 
+To delete multiple metadata components, either set multiple --metadata <name> flags or a single --metadata flag with multiple names separated by spaces. Enclose names that contain spaces in one set of double quotes. The same syntax applies to --manifest and --source-dir.
+
 # examples
 
 - Delete all local Apex source files and all Apex classes from the org with alias "my-scratch":
@@ -32,11 +34,11 @@ When you run this command, both the local source file and the metadata component
 
 # flags.source-dir.summary
 
-Comma-separated list of source file paths to delete.
+Source file paths to delete.
 
 # flags.metadata.summary
 
-Comma-separated list of names of metadata components to delete.
+Metadata components to delete.
 
 # flags.no-prompt.summary
 

--- a/messages/delete.source.md
+++ b/messages/delete.source.md
@@ -4,7 +4,7 @@ Delete source from your project and from a non-source-tracked org.
 
 # description
 
-Use this command to delete components from orgs that don’t have source tracking. To remove deleted items from orgs that have source tracking enabled, "sf project deploy start".
+Use this command to delete components from orgs that don’t have source tracking. To remove deleted items from orgs that have source tracking enabled, "<%= config.bin %> project deploy start".
 
 When you run this command, both the local source file and the metadata component in the org are deleted.
 

--- a/messages/deploy.async.md
+++ b/messages/deploy.async.md
@@ -8,12 +8,12 @@ Deploy has been queued for cancellation.
 
 # info.AsyncDeployCancel
 
-Run "sf project deploy cancel --job-id %s" to cancel the deploy.
+Run "%s project deploy cancel --job-id %s" to cancel the deploy.
 
 # info.AsyncDeployStatus
 
-Run "sf project deploy report --job-id %s" to get the latest status.
+Run "%s project deploy report --job-id %s" to get the latest status.
 
 # info.AsyncDeployResume
 
-Run "sf project deploy resume --job-id %s" to resume watching the deploy.
+Run "%s project deploy resume --job-id %s" to resume watching the deploy.

--- a/messages/deploy.md
+++ b/messages/deploy.md
@@ -12,7 +12,7 @@ For example, if your local project contains a source directory with metadata fil
 
 The command stores your responses in the "deploy-options.json" file in your local project directory and uses them as defaults when you rerun the command. Specify --interactive to force the command to reprompt.
 
-Use this command for quick and simple deploys. For more complicated deployments, use the environment-specific commands, such as "sf project deploy start", that provide additional flags.
+Use this command for quick and simple deploys. For more complicated deployments, use the environment-specific commands, such as "<%= config.bin %> project deploy start", that provide additional flags.
 
 # examples
 

--- a/messages/deploy.metadata.cancel.md
+++ b/messages/deploy.metadata.cancel.md
@@ -47,7 +47,7 @@ Number of minutes to wait for the command to complete and display results.
 
 # flags.wait.description
 
-If the command continues to run after the wait period, the CLI returns control of the terminal window to you. To resume watching the cancellation, run "sf project deploy resume". To check the status of the cancellation, run "<%= config.bin %> project deploy report".
+If the command continues to run after the wait period, the CLI returns control of the terminal window to you. To resume watching the cancellation, run "<%= config.bin %> project deploy resume". To check the status of the cancellation, run "<%= config.bin %> project deploy report".
 
 # flags.async.summary
 
@@ -55,7 +55,7 @@ Run the command asynchronously.
 
 # flags.async.description
 
-The command immediately returns the control of the terminal to you. This way, you can continue to use the CLI. To resume watching the cancellation, run "sf project deploy resume". To check the status of the cancellation, run "<%= config.bin %> project deploy report".
+The command immediately returns the control of the terminal to you. This way, you can continue to use the CLI. To resume watching the cancellation, run "<%= config.bin %> project deploy resume". To check the status of the cancellation, run "<%= config.bin %> project deploy report".
 
 # error.CannotCancelDeploy
 

--- a/messages/deploy.metadata.md
+++ b/messages/deploy.metadata.md
@@ -56,17 +56,17 @@ To deploy multiple metadata components, either set multiple --metadata <name> fl
 
 Login username or alias for the target org.
 
-# flags.pre-destructive-changes
+# flags.pre-destructive-changes.summary
 
-file path for a manifest (destructiveChangesPre.xml) of components to delete before the deploy
+File path for a manifest (destructiveChangesPre.xml) of components to delete before the deploy
 
-# flags.post-destructive-changes
+# flags.post-destructive-changes.summary
 
-file path for a manifest (destructiveChangesPost.xml) of components to delete after the deploy
+File path for a manifest (destructiveChangesPost.xml) of components to delete after the deploy.
 
-# flags.purge-on-delete
+# flags.purge-on-delete.summary
 
-specify that deleted components in the destructive changes manifest file are immediately eligible for deletion rather than being stored in the Recycle Bin
+Specify that deleted components in the destructive changes manifest file are immediately eligible for deletion rather than being stored in the Recycle Bin.
 
 # flags.target-org.description
 
@@ -223,17 +223,17 @@ No local changes to deploy.
 
 - To see conflicts and ignored files, run "%s project deploy preview" with any of the manifest, directory, or metadata flags.
 
-# flags.junit
+# flags.junit.summary
 
-output JUnit test results
+Output JUnit test results.
 
-# flags.coverage-formatters
+# flags.coverage-formatters.summary
 
-format of the code coverage results
+Format of the code coverage results.
 
-# flags.results-dir
+# flags.results-dir.summary
 
-output directory for code coverage and JUnit results; defaults to the deploy ID
+Output directory for code coverage and JUnit results; defaults to the deploy ID.
 
 # asyncCoverageJunitWarning
 

--- a/messages/deploy.metadata.md
+++ b/messages/deploy.metadata.md
@@ -110,7 +110,7 @@ Number of minutes to wait for command to complete and display results.
 
 # flags.wait.description
 
-If the command continues to run after the wait period, the CLI returns control of the terminal window to you and returns the job ID. To resume the deployment, run "sf project deploy resume". To check the status of the deployment, run "sf project deploy report".
+If the command continues to run after the wait period, the CLI returns control of the terminal window to you and returns the job ID. To resume the deployment, run "<%= config.bin %> project deploy resume". To check the status of the deployment, run "<%= config.bin %> project deploy report".
 
 # flags.manifest.summary
 
@@ -178,7 +178,7 @@ Run the command asynchronously.
 
 # flags.async.description
 
-The command immediately returns the job ID and control of the terminal to you. This way, you can continue to use the CLI. To resume the deployment, run "sf project deploy resume". To check the status of the deployment, run "sf project deploy report".
+The command immediately returns the job ID and control of the terminal to you. This way, you can continue to use the CLI. To resume the deployment, run "<%= config.bin %> project deploy resume". To check the status of the deployment, run "<%= config.bin %> project deploy report".
 
 # flags.metadata-dir.summary
 
@@ -203,7 +203,7 @@ You must specify tests using the --tests flag if the --test-level flag is set to
 
 # error.ClientTimeout
 
-The command has timed out, although the deployment is still running. Use "sf project deploy resume" to resume watching the deployment.
+The command has timed out, although the deployment is still running. Use "%s project deploy resume" to resume watching the deployment.
 
 # error.Conflicts
 
@@ -213,7 +213,7 @@ There are changes in the org that conflict with the local changes you're trying 
 
 - To overwrite the remote changes, rerun this command with the --ignore-conflicts flag.
 
-- To overwrite the local changes, run the "sf project retrieve start" command with the --ignore-conflicts flag.
+- To overwrite the local changes, run the "%s project retrieve start" command with the --ignore-conflicts flag.
 
 # error.nothingToDeploy
 
@@ -221,7 +221,7 @@ No local changes to deploy.
 
 # error.nothingToDeploy.Actions
 
-- To see conflicts and ignored files, run "sf project deploy preview" with any of the manifest, directory, or metadata flags.
+- To see conflicts and ignored files, run "%s project deploy preview" with any of the manifest, directory, or metadata flags.
 
 # flags.junit
 

--- a/messages/deploy.metadata.preview.md
+++ b/messages/deploy.metadata.preview.md
@@ -94,4 +94,4 @@ There are changes in the org that conflict with the local changes you're trying 
 
 - To overwrite the remote changes, rerun this command with the --ignore-conflicts flag.
 
-- To overwrite the local changes, run the "sf project retrieve start" command with the --ignore-conflicts flag.
+- To overwrite the local changes, run the "%s project retrieve start" command with the --ignore-conflicts flag.

--- a/messages/deploy.metadata.preview.md
+++ b/messages/deploy.metadata.preview.md
@@ -68,7 +68,7 @@ All child components are included. If you specify this flag, don’t specify --m
 
 # flags.ignore-conflicts.summary
 
-Ignore conflicts and deploy local files, even if they overwrite changes in the org.
+Don't display conflicts between your local project and the org.
 
 # flags.ignore-conflicts.description
 

--- a/messages/deploy.metadata.preview.md
+++ b/messages/deploy.metadata.preview.md
@@ -16,13 +16,13 @@ To preview the deployment of multiple metadata components, either set multiple -
 
 - NOTE: The commands to preview a deployment and actually deploy it use similar flags. We provide a few preview examples here, but see the help for "<%= config.bin %> project deploy start" for more examples that you can adapt for previewing.
 
-- Preview the deployment of source files in a directory, such as force-app:
+- Preview the deployment of source files in a directory, such as force-app, to your default org:
 
       <%= config.bin %> <%= command.id %>  --source-dir force-app
 
-- Preview the deployment of all Apex classes:
+- Preview the deployment of all Apex classes to an org with alias "my-scratch":
 
-      <%= config.bin %> <%= command.id %> --metadata ApexClass
+      <%= config.bin %> <%= command.id %> --metadata ApexClass --target-org my-scratch
 
 - Preview deployment of a specific Apex class:
 
@@ -68,7 +68,7 @@ All child components are included. If you specify this flag, don’t specify --m
 
 # flags.ignore-conflicts.summary
 
-Don't display conflicts between your local project and the org.
+Don't display conflicts in preview of the deployment.
 
 # flags.ignore-conflicts.description
 

--- a/messages/deploy.metadata.report.md
+++ b/messages/deploy.metadata.report.md
@@ -49,14 +49,14 @@ Use the job ID of the most recent deploy operation.
 
 For performance reasons, this flag uses job IDs for deploy operations that started only in the past 3 days or less. If your most recent operation was more than 3 days ago, this flag won't find a job ID.
 
-# flags.junit
+# flags.junit.summary
 
-output JUnit test results
+Output JUnit test results.
 
-# flags.coverage-formatters
+# flags.coverage-formatters.summary
 
-format of the code coverage results
+Format of the code coverage results
 
-# flags.results-dir
+# flags.results-dir.summary
 
-output directory for code coverage and JUnit results; defaults to the deploy ID
+Output directory for code coverage and JUnit results; defaults to the deploy ID.

--- a/messages/deploy.metadata.resume.md
+++ b/messages/deploy.metadata.resume.md
@@ -61,14 +61,14 @@ Show concise output of the deploy operation result.
 
 Job ID %s is not resumable with status %s.
 
-# flags.junit
+# flags.junit.summary
 
-output JUnit test results
+Output JUnit test results.
 
-# flags.coverage-formatters
+# flags.coverage-formatters.summary
 
-format of the code coverage results
+Format of the code coverage results.
 
-# flags.results-dir
+# flags.results-dir.summary
 
-output directory for code coverage and JUnit results; defaults to the deploy ID
+Output directory for code coverage and JUnit results; defaults to the deploy ID.

--- a/messages/list.ignored.md
+++ b/messages/list.ignored.md
@@ -1,16 +1,28 @@
+# summary
+
+Check your local project package directories for forceignored files.
+
 # description
 
-check your local project package directories for forceignored files
+When deploying or retrieving metadata between your local project and an org, you can specify the source files you want to exclude with a .forceignore file. The .forceignore file structure mimics the .gitignore structure. Each line in .forceignore specifies a pattern that corresponds to one or more files. The files typically represent metadata components, but can be any files you want to exclude, such as LWC configuration JSON files or tests.
 
 # examples
 
-- $ <%= config.bin %> <%= command.id %>
+- List all the files in all package directories that are ignored:
 
-- $ <%= config.bin %> <%= command.id %> --source-dir force-app
+  <%= config.bin %> <%= command.id %>
 
-# flags.source-dir
+- List all the files in a specific directory that are ignored:
 
-file or directory of files that the command checks for foreceignored files
+  <%= config.bin %> <%= command.id %> --source-dir force-app
+
+- Check if a particular file is ignored:
+
+  <%= config.bin %> <%= command.id %> --source-dir package.xml
+
+# flags.source-dir.summary
+
+File or directory of files that the command checks for foreceignored files.
 
 # invalidSourceDir
 

--- a/messages/manifest.create.md
+++ b/messages/manifest.create.md
@@ -17,11 +17,13 @@ See https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/met
 
 Use --manifest-name to specify a custom name for the generated manifest if the pre-defined ones don’t suit your needs. You can specify either --manifest-type or --manifest-name, but not both.
 
+To include multiple metadata components, either set multiple --metadata <name> flags or a single --metadata flag with multiple names separated by spaces. Enclose names that contain spaces in one set of double quotes. The same syntax applies to --include-packages and --source-dir.
+
 # examples
 
-- Create a manifest for deploying or retrieving all Apex classes:
+- Create a manifest for deploying or retrieving all Apex classes and custom objects:
 
-  $ <%= config.bin %> <%= command.id %> --metadata ApexClass
+  $ <%= config.bin %> <%= command.id %> --metadata ApexClass --metadata CustomObject
 
 - Create a manifest for deleting the specified Apex class:
 
@@ -37,7 +39,7 @@ Use --manifest-name to specify a custom name for the generated manifest if the p
 
 # flags.include-packages.summary
 
-Comma-separated list of package types (managed, unlocked) whose metadata is included in the manifest; by default, metadata in packages is ignored.
+Package types (managed, unlocked) whose metadata is included in the manifest; by default, metadata in packages is ignored.
 
 # flags.from-org.summary
 
@@ -57,11 +59,11 @@ Directory to save the created manifest.
 
 # flags.source-dir.summary
 
-Comma-separated list of paths to the local source files to include in the manifest.
+Paths to the local source files to include in the manifest.
 
 # flags.metadata.summary
 
-Comma-separated list of names of metadata components to include in the manifest.
+Names of metadata components to include in the manifest.
 
 # success
 

--- a/messages/retrieve.metadata.md
+++ b/messages/retrieve.metadata.md
@@ -157,7 +157,7 @@ There are changes in your local files that conflict with the org changes you're 
 
 - To overwrite the local changes, rerun this command with the --ignore-conflicts flag.
 
-- To overwrite the remote changes, run the "sf project deploy start" command with the --ignore-conflicts flag.
+- To overwrite the remote changes, run the "%s project deploy start" command with the --ignore-conflicts flag.
 
 # info.WroteZipFile
 

--- a/messages/retrieve.metadata.md
+++ b/messages/retrieve.metadata.md
@@ -14,13 +14,13 @@ To retrieve multiple metadata components, either use multiple --metadata <name> 
 
 # examples
 
-- Retrieve remote changes:
+- Retrieve remote changes from your default org:
 
   <%= config.bin %> <%= command.id %>
 
-- Retrieve the source files in a directory:
+- Retrieve the source files in a directory from an org with alias "my-scratch":
 
-  <%= config.bin %> <%= command.id %> --source-dir path/to/source
+  <%= config.bin %> <%= command.id %> --source-dir path/to/source --target-org my-scratch
 
 - Retrieve a specific Apex class and the objects whose source is in a directory (both examples are equivalent):
 

--- a/messages/retrieve.metadata.preview.md
+++ b/messages/retrieve.metadata.preview.md
@@ -12,13 +12,13 @@ If your org allows source tracking, then this command considers conflicts betwee
 
 # examples
 
-- Preview the retrieve of all changes from the org:
+- Preview the retrieve of all changes from your default org:
 
   <%= config.bin %> <%= command.id %>
 
-- Preview the retrieve when ignoring any conflicts:
+- Preview the retrieve when ignoring any conflicts from an org with alias "my-scratch":
 
-  <%= config.bin %> <%= command.id %> --ignore-conflicts
+  <%= config.bin %> <%= command.id %> --ignore-conflicts --target-org my-scratch
 
 # flags.target-org.summary
 
@@ -30,7 +30,7 @@ Overrides your default org.
 
 # flags.ignore-conflicts.summary
 
-Ignore conflicts and preview the retrieve of remote components, even if they will overwrite local changes.
+Don't display conflicts in the preview of the retrieval.
 
 # flags.ignore-conflicts.description
 

--- a/src/commands/project/deploy/cancel.ts
+++ b/src/commands/project/deploy/cancel.ts
@@ -77,7 +77,7 @@ export default class DeployMetadataCancel extends SfCommand<DeployResultJson> {
 
     if (flags.async) {
       const asyncResult = await cancelDeployAsync({ 'target-org': deployOpts['target-org'] }, jobId);
-      const formatter = new AsyncDeployCancelResultFormatter(asyncResult.id);
+      const formatter = new AsyncDeployCancelResultFormatter(asyncResult.id, this.config.bin);
       if (!this.jsonEnabled()) formatter.display();
       return formatter.getJson();
     } else {

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -97,7 +97,7 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
     this.log(`Deploy ID: ${bold(jobId)}`);
 
     if (flags.async) {
-      const asyncFormatter = new AsyncDeployResultFormatter(jobId);
+      const asyncFormatter = new AsyncDeployResultFormatter(jobId, 'sf');
       if (!this.jsonEnabled()) asyncFormatter.display();
       return asyncFormatter.getJson();
     }

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -97,7 +97,7 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
     this.log(`Deploy ID: ${bold(jobId)}`);
 
     if (flags.async) {
-      const asyncFormatter = new AsyncDeployResultFormatter(jobId, 'sf');
+      const asyncFormatter = new AsyncDeployResultFormatter(jobId, this.config.bin);
       if (!this.jsonEnabled()) asyncFormatter.display();
       return asyncFormatter.getJson();
     }

--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -47,14 +47,14 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
     }),
     'coverage-formatters': Flags.string({
       multiple: true,
-      summary: messages.getMessage('flags.coverage-formatters'),
+      summary: messages.getMessage('flags.coverage-formatters.summary'),
       options: reportsFormatters,
       helpValue: reportsFormatters.join(','),
     }),
-    junit: Flags.boolean({ summary: messages.getMessage('flags.junit') }),
+    junit: Flags.boolean({ summary: messages.getMessage('flags.junit.summary') }),
     'results-dir': Flags.directory({
       dependsOn: ['junit', 'coverage-formatters'],
-      summary: messages.getMessage('flags.results-dir'),
+      summary: messages.getMessage('flags.results-dir.summary'),
     }),
   };
 

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -92,6 +92,7 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
     const { deploy, componentSet } = await executeDeploy(
       // there will always be conflicts on a resume if anything deployed--the changes on the server are not synced to local
       { ...deployOpts, wait, 'dry-run': false, 'ignore-conflicts': true },
+      this.config.bin,
       this.project,
       jobId
     );

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -63,14 +63,14 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
     }),
     'coverage-formatters': Flags.string({
       multiple: true,
-      summary: messages.getMessage('flags.coverage-formatters'),
+      summary: messages.getMessage('flags.coverage-formatters.summary'),
       options: reportsFormatters,
       helpValue: reportsFormatters.join(','),
     }),
-    junit: Flags.boolean({ summary: messages.getMessage('flags.junit') }),
+    junit: Flags.boolean({ summary: messages.getMessage('flags.junit.summary') }),
     'results-dir': Flags.directory({
       dependsOn: ['junit', 'coverage-formatters'],
-      summary: messages.getMessage('flags.results-dir'),
+      summary: messages.getMessage('flags.results-dir.summary'),
     }),
   };
 

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -132,28 +132,28 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       exclusive: ['async'],
     }),
     'purge-on-delete': Flags.boolean({
-      summary: messages.getMessage('flags.purge-on-delete'),
+      summary: messages.getMessage('flags.purge-on-delete.summary'),
       dependsOn: ['manifest'],
       relationships: [{ type: 'some', flags: ['pre-destructive-changes', 'post-destructive-changes'] }],
     }),
     'pre-destructive-changes': Flags.file({
-      summary: messages.getMessage('flags.pre-destructive-changes'),
+      summary: messages.getMessage('flags.pre-destructive-changes.summary'),
       dependsOn: ['manifest'],
     }),
     'post-destructive-changes': Flags.file({
-      summary: messages.getMessage('flags.post-destructive-changes'),
+      summary: messages.getMessage('flags.post-destructive-changes.summary'),
       dependsOn: ['manifest'],
     }),
     'coverage-formatters': Flags.string({
       multiple: true,
-      summary: messages.getMessage('flags.coverage-formatters'),
+      summary: messages.getMessage('flags.coverage-formatters.summary'),
       options: reportsFormatters,
       helpValue: reportsFormatters.join(','),
     }),
-    junit: Flags.boolean({ summary: messages.getMessage('flags.junit'), dependsOn: ['coverage-formatters'] }),
+    junit: Flags.boolean({ summary: messages.getMessage('flags.junit.summary'), dependsOn: ['coverage-formatters'] }),
     'results-dir': Flags.directory({
       dependsOn: ['coverage-formatters'],
-      summary: messages.getMessage('flags.results-dir'),
+      summary: messages.getMessage('flags.results-dir.summary'),
     }),
   };
 

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -185,6 +185,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
         'target-org': flags['target-org'].getUsername(),
         api,
       },
+      this.config.bin,
       this.project
     );
 
@@ -196,7 +197,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       if (flags['coverage-formatters']) {
         this.warn(messages.getMessage('asyncCoverageJunitWarning'));
       }
-      const asyncFormatter = new AsyncDeployResultFormatter(deploy.id);
+      const asyncFormatter = new AsyncDeployResultFormatter(deploy.id, this.config.bin);
       if (!this.jsonEnabled()) asyncFormatter.display();
       return asyncFormatter.getJson();
     }
@@ -225,12 +226,12 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
         return super.catch({
           ...error,
           message: messages.getMessage('error.Conflicts'),
-          actions: messages.getMessages('error.Conflicts.Actions'),
+          actions: messages.getMessages('error.Conflicts.Actions', [this.config.bin]),
         });
       }
     }
     if (error.message.includes('client has timed out')) {
-      const err = messages.createError('error.ClientTimeout');
+      const err = messages.createError('error.ClientTimeout', [this.config.bin]);
       return super.catch({ ...error, name: err.name, message: err.message, code: err.code });
     }
     return super.catch(error);

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -131,6 +131,7 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
         'target-org': flags['target-org'].getUsername(),
         api,
       },
+      this.config.bin,
       this.project
     );
 
@@ -139,7 +140,7 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
     new DeployProgress(deploy, this.jsonEnabled()).start();
 
     if (flags.async) {
-      const asyncFormatter = new AsyncDeployResultFormatter(deploy.id);
+      const asyncFormatter = new AsyncDeployResultFormatter(deploy.id, this.config.bin);
       if (!this.jsonEnabled()) asyncFormatter.display();
       return asyncFormatter.getJson();
     }

--- a/src/commands/project/list/ignored.ts
+++ b/src/commands/project/list/ignored.ts
@@ -18,7 +18,7 @@ export type SourceIgnoredResults = {
 };
 
 export class Ignored extends SfCommand<SourceIgnoredResults> {
-  public static readonly summary = messages.getMessage('description');
+  public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
@@ -29,7 +29,7 @@ export class Ignored extends SfCommand<SourceIgnoredResults> {
       char: 'p',
       aliases: ['sourcepath'],
       deprecateAliases: true,
-      summary: messages.getMessage('flags.source-dir'),
+      summary: messages.getMessage('flags.source-dir.summary'),
     }),
   };
 

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -250,7 +250,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
         return super.catch({
           ...error,
           message: messages.getMessage('error.Conflicts'),
-          actions: messages.getMessages('error.Conflicts.Actions'),
+          actions: messages.getMessages('error.Conflicts.Actions', [this.config.bin]),
         });
       }
     }

--- a/src/formatters/asyncDeployCancelResultFormatter.ts
+++ b/src/formatters/asyncDeployCancelResultFormatter.ts
@@ -13,7 +13,7 @@ Messages.importMessagesDirectory(__dirname);
 export const deployAsyncMessages = Messages.loadMessages('@salesforce/plugin-deploy-retrieve', 'deploy.async');
 
 export class AsyncDeployCancelResultFormatter implements Formatter<AsyncDeployResultJson> {
-  public constructor(private id: string) {}
+  public constructor(private id: string, private bin: string) {}
 
   public getJson(): DeployResultJson {
     return { id: this.id, done: false, status: 'Queued', files: [] };
@@ -21,7 +21,7 @@ export class AsyncDeployCancelResultFormatter implements Formatter<AsyncDeployRe
 
   public display(): void {
     ux.log(deployAsyncMessages.getMessage('info.AsyncDeployCancelQueued'));
-    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployResume', [this.id]));
-    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployStatus', [this.id]));
+    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployResume', [this.bin, this.id]));
+    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployStatus', [this.bin, this.id]));
   }
 }

--- a/src/formatters/asyncDeployResultFormatter.ts
+++ b/src/formatters/asyncDeployResultFormatter.ts
@@ -12,7 +12,7 @@ Messages.importMessagesDirectory(__dirname);
 export const deployAsyncMessages = Messages.loadMessages('@salesforce/plugin-deploy-retrieve', 'deploy.async');
 
 export class AsyncDeployResultFormatter implements Formatter<AsyncDeployResultJson> {
-  public constructor(private id: string) {}
+  public constructor(private id: string, private bin: string) {}
 
   public getJson(): AsyncDeployResultJson {
     return { id: this.id, done: false, status: 'Queued', files: [] };
@@ -21,8 +21,8 @@ export class AsyncDeployResultFormatter implements Formatter<AsyncDeployResultJs
   public display(): void {
     ux.log(deployAsyncMessages.getMessage('info.AsyncDeployQueued'));
     ux.log();
-    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployResume', [this.id]));
-    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployStatus', [this.id]));
-    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployCancel', [this.id]));
+    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployResume', [this.bin, this.id]));
+    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployStatus', [this.bin, this.id]));
+    ux.log(deployAsyncMessages.getMessage('info.AsyncDeployCancel', [this.bin, this.id]));
   }
 }

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -106,6 +106,7 @@ export async function buildComponentSet(opts: Partial<DeployOptions>, stl?: Sour
 
 export async function executeDeploy(
   opts: Partial<DeployOptions>,
+  bin = 'sf',
   project?: SfProject,
   id?: string
 ): Promise<{ deploy: MetadataApiDeploy; componentSet?: ComponentSet }> {
@@ -152,7 +153,7 @@ export async function executeDeploy(
       throw new SfError(
         deployMessages.getMessage('error.nothingToDeploy'),
         'NothingToDeploy',
-        deployMessages.getMessages('error.nothingToDeploy.Actions')
+        deployMessages.getMessages('error.nothingToDeploy.Actions', [bin])
       );
     }
     deploy = id


### PR DESCRIPTION
### What does this PR do?
fixes hardcoded `sf` references in messages.  

replaced with `config.bin`

Also includes various other edits to the messages files. 

### What issues does this PR fix or reference?
[skip-validate-pr] - found in blitz