### PR TITLE
Sm/cancel nut

### DIFF
--- a/src/commands/project/deploy/cancel.ts
+++ b/src/commands/project/deploy/cancel.ts
@@ -87,7 +87,9 @@ export default class DeployMetadataCancel extends SfCommand<DeployResultJson> {
 
       cache.update(result.response.id, { status: result.response.status });
       await cache.write();
-
+      if ([RequestStatus.Succeeded, RequestStatus.SucceededPartial].includes(result.response.status)) {
+        throw messages.createError('error.CannotCancelDeploy');
+      }
       return formatter.getJson();
     }
   }


### PR DESCRIPTION
### What does this PR do?
the cancel command should return 1 in more circumstances (like when you try to cancel a deploy but it's already done)

The NUTs were catching this, intermittently, on windows where the cancel would rarely make it in time.  ex: https://github.com/salesforcecli/plugin-deploy-retrieve/actions/runs/4523309135/jobs/7966365580
 
### What issues does this PR fix or reference?
all part of the "the blitz"