### PR TITLE
refactor: ts strict mode changes (esp deploy.id)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "shx": "0.3.4",
     "sinon": "11.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.3",
     "wireit": "^0.9.5"
   },
   "config": {},

--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -378,6 +378,12 @@ export class Source extends SfCommand<DeleteSourceJson> {
   private async moveBundleToManifest(bundle: SourceComponent, sourcepath: string): Promise<void> {
     // if one of the passed in sourcepaths is to a bundle component
     const fileName = path.basename(sourcepath);
+    if (!bundle.name) {
+      throw new SfError(
+        `No bundle name found for component ${bundle.fullName} at ${bundle.xml ?? bundle.content})`,
+        'NoBundleNameFound'
+      );
+    }
     const fullName = path.join(bundle.name, fileName);
     this.mixedDeployDelete.delete.push({
       state: ComponentStatus.Deleted,

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -192,7 +192,8 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
     const { deploy, componentSet } = await executeDeploy(
       {
         ...flags,
-        'target-org': flags['target-org'].getUsername(),
+        // TODO: org authinfo retrieve from FS always has username W-12659566
+        'target-org': flags['target-org'].getUsername() as string,
         api,
       },
       this.config.bin,

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -127,7 +127,8 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
         ...flags,
         'ignore-conflicts': true,
         'dry-run': true,
-        'target-org': flags['target-org'].getUsername(),
+        // TODO: org authinfo retrieve from FS always has username W-12659566
+        'target-org': flags['target-org'].getUsername() as string,
         api,
       },
       this.config.bin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8569,7 +8569,7 @@ typedoc@0.23.16:
     minimatch "^5.1.0"
     shiki "^0.11.1"
 
-typescript@^4.1.3, typescript@^4.9.5, typescript@~4.9.3:
+typescript@^4.1.3, typescript@~4.9.3:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
@@ -8578,6 +8578,11 @@ typescript@^4.1.3, typescript@^4.9.5, typescript@~4.9.3:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
   integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
+
+typescript@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
+  integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
 
 uglify-js@^3.1.4, uglify-js@^3.1.9:
   version "3.17.4"


### PR DESCRIPTION
> requires https://github.com/salesforcecli/plugin-deploy-retrieve/pull/571

### What does this PR do?
changes related to SDR using ts-strict mode

SDR's refactor of deploy.id (to know whether it's a string or undefined if it's passed in) has ripple effects on users of deploy.id

### What issues does this PR fix or reference?
@W-12671663@