### PR TITLE
refactor: handle undefined deployId

### DIFF
--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -233,7 +233,9 @@ export class Source extends SfCommand<DeleteSourceJson> {
 
     new DeployProgress(deploy, this.jsonEnabled()).start();
     this.deployResult = await deploy.pollStatus({ timeout: this.flags.wait });
-
+    if (typeof deploy.id !== 'string') {
+      throw new SfError('The deploy id is not a string');
+    }
     await DeployCache.update(deploy.id, { status: this.deployResult.response.status });
 
     await Lifecycle.getInstance().emit('postdeploy', this.deployResult);
@@ -378,6 +380,9 @@ export class Source extends SfCommand<DeleteSourceJson> {
   private async moveBundleToManifest(bundle: SourceComponent, sourcepath: string): Promise<void> {
     // if one of the passed in sourcepaths is to a bundle component
     const fileName = path.basename(sourcepath);
+    if (!bundle.name) {
+      throw new SfError(`Unable to find bundle name for ${sourcepath}`);
+    }
     const fullName = path.join(bundle.name, fileName);
     this.mixedDeployDelete.delete.push({
       state: ComponentStatus.Deleted,

--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -233,8 +233,8 @@ export class Source extends SfCommand<DeleteSourceJson> {
 
     new DeployProgress(deploy, this.jsonEnabled()).start();
     this.deployResult = await deploy.pollStatus({ timeout: this.flags.wait });
-    if (typeof deploy.id !== 'string') {
-      throw new SfError('The deploy id is not a string');
+    if (!deploy.id) {
+      throw new SfError('The deploy id is not available.');
     }
     await DeployCache.update(deploy.id, { status: this.deployResult.response.status });
 

--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -380,9 +380,6 @@ export class Source extends SfCommand<DeleteSourceJson> {
   private async moveBundleToManifest(bundle: SourceComponent, sourcepath: string): Promise<void> {
     // if one of the passed in sourcepaths is to a bundle component
     const fileName = path.basename(sourcepath);
-    if (!bundle.name) {
-      throw new SfError(`Unable to find bundle name for ${sourcepath}`);
-    }
     const fullName = path.join(bundle.name, fileName);
     this.mixedDeployDelete.delete.push({
       state: ComponentStatus.Deleted,

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -110,8 +110,8 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
     });
 
     if (!this.jsonEnabled()) formatter.display();
-    if (typeof deploy.id !== 'string') {
-      throw new SfError('The deploy id is not a string');
+    if (!deploy.id) {
+      throw new SfError('The deploy id is not available.');
     }
     cache.update(deploy.id, { status: result.response.status });
     await cache.write();

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -6,7 +6,7 @@
  */
 
 import { bold } from 'chalk';
-import { EnvironmentVariable, Messages } from '@salesforce/core';
+import { EnvironmentVariable, Messages, SfError } from '@salesforce/core';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { Duration } from '@salesforce/kit';
 import { getVersionMessage } from '../../../utils/output';
@@ -110,7 +110,9 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
     });
 
     if (!this.jsonEnabled()) formatter.display();
-
+    if (typeof deploy.id !== 'string') {
+      throw new SfError('The deploy id is not a string');
+    }
     cache.update(deploy.id, { status: result.response.status });
     await cache.write();
 

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -201,8 +201,8 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
 
     const action = flags['dry-run'] ? 'Deploying (dry-run)' : 'Deploying';
     this.log(getVersionMessage(action, componentSet, api));
-    if (typeof deploy.id !== 'string') {
-      throw new SfError('The deploy id is not a string');
+    if (!deploy.id) {
+      throw new SfError('The deploy id is not available.');
     }
     this.log(`Deploy ID: ${bold(deploy.id)}`);
 

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -201,6 +201,9 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
 
     const action = flags['dry-run'] ? 'Deploying (dry-run)' : 'Deploying';
     this.log(getVersionMessage(action, componentSet, api));
+    if (typeof deploy.id !== 'string') {
+      throw new SfError('The deploy id is not a string');
+    }
     this.log(`Deploy ID: ${bold(deploy.id)}`);
 
     if (flags.async) {

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -135,8 +135,8 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
     );
 
     this.log(getVersionMessage('Validating Deployment', componentSet, api));
-    if (typeof deploy.id !== 'string') {
-      throw new SfError('The deploy id is not a string');
+    if (!deploy.id) {
+      throw new SfError('The deploy id is not available.');
     }
     this.log(`Deploy ID: ${bold(deploy.id)}`);
 

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { bold } from 'chalk';
-import { EnvironmentVariable, Messages, OrgConfigProperties } from '@salesforce/core';
+import { EnvironmentVariable, Messages, OrgConfigProperties, SfError } from '@salesforce/core';
 import { RequestStatus } from '@salesforce/source-deploy-retrieve';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { getVersionMessage } from '../../../utils/output';
@@ -135,6 +135,9 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
     );
 
     this.log(getVersionMessage('Validating Deployment', componentSet, api));
+    if (typeof deploy.id !== 'string') {
+      throw new SfError('The deploy id is not a string');
+    }
     this.log(`Deploy ID: ${bold(deploy.id)}`);
 
     if (flags.async) {

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -164,8 +164,8 @@ export async function executeDeploy(
         });
   }
 
-  if (typeof deploy.id !== 'string') {
-    throw new SfError('The deploy id is not a string');
+  if (!deploy.id) {
+    throw new SfError('The deploy id is not available.');
   }
 
   // does not apply to mdapi deploys
@@ -180,8 +180,8 @@ export async function cancelDeploy(opts: Partial<DeployOptions>, id: string): Pr
   const usernameOrConnection = org.getUsername() ?? org.getConnection();
 
   const deploy = new MetadataApiDeploy({ usernameOrConnection, id });
-  if (typeof deploy.id !== 'string') {
-    throw new SfError('The deploy id is not a string');
+  if (!deploy.id) {
+    throw new SfError('The deploy id is not available.');
   }
   const componentSet = await buildComponentSet({ ...opts });
   await DeployCache.set(deploy.id, { ...opts });
@@ -195,8 +195,8 @@ export async function cancelDeployAsync(opts: Partial<DeployOptions>, id: string
   const usernameOrConnection = org.getUsername() ?? org.getConnection();
   const deploy = new MetadataApiDeploy({ usernameOrConnection, id });
   await deploy.cancel();
-  if (typeof deploy.id !== 'string') {
-    throw new SfError('The deploy id is not a string');
+  if (!deploy.id) {
+    throw new SfError('The deploy id is not available.');
   }
   return { id: deploy.id };
 }

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -164,6 +164,10 @@ export async function executeDeploy(
         });
   }
 
+  if (typeof deploy.id !== 'string') {
+    throw new SfError('The deploy id is not a string');
+  }
+
   // does not apply to mdapi deploys
   const manifestPath = componentSet ? await writeManifest(deploy.id, componentSet) : undefined;
   await DeployCache.set(deploy.id, { ...opts, manifest: manifestPath });
@@ -176,7 +180,9 @@ export async function cancelDeploy(opts: Partial<DeployOptions>, id: string): Pr
   const usernameOrConnection = org.getUsername() ?? org.getConnection();
 
   const deploy = new MetadataApiDeploy({ usernameOrConnection, id });
-
+  if (typeof deploy.id !== 'string') {
+    throw new SfError('The deploy id is not a string');
+  }
   const componentSet = await buildComponentSet({ ...opts });
   await DeployCache.set(deploy.id, { ...opts });
 
@@ -189,6 +195,9 @@ export async function cancelDeployAsync(opts: Partial<DeployOptions>, id: string
   const usernameOrConnection = org.getUsername() ?? org.getConnection();
   const deploy = new MetadataApiDeploy({ usernameOrConnection, id });
   await deploy.cancel();
+  if (typeof deploy.id !== 'string') {
+    throw new SfError('The deploy id is not a string');
+  }
   return { id: deploy.id };
 }
 


### PR DESCRIPTION
### What does this PR do?
sdr doesn't provide good typing for deploy.id (it's a couple layers of inheritance with a getter that's marked as string | undefined.

rather than adding more complexity (and likely a breaking change) to sdr types, any consumer using strict types must handle the ambiguous typing.

A better long-term solution would be to use generics on the layers above sdr/metadataTransfer (ie, metadataApiDeploy|Retrieve and componentSet.deploy|retrieve) to make it clear when the id is set [when it's passed in, when start has already been called] vs not.

### What issues does this PR fix or reference?
@W-12671663@