### PR TITLE
test: expect metafile path for preview command

### DIFF
--- a/test/nuts/digitalExperienceBundle/helper.ts
+++ b/test/nuts/digitalExperienceBundle/helper.ts
@@ -138,7 +138,7 @@ export function assertViewHomeStatus(resp: CustomFileResponses, deb: 'a' | 'b') 
   expect(resp[0]).to.include({
     type: TYPES.DE?.name,
     fullName: deb === 'a' ? FULL_NAMES.DE_VIEW_HOME_A : FULL_NAMES.DE_VIEW_HOME_B,
-    filePath: deb === 'a' ? FILE_RELATIVE_PATHS.DE_VIEW_HOME_COMPONENT_A : FILE_RELATIVE_PATHS.DE_VIEW_HOME_COMPONENT_B,
+    filePath: deb === 'a' ? FILE_RELATIVE_PATHS.DE_VIEW_HOME_META_A : FILE_RELATIVE_PATHS.DE_VIEW_HOME_META_B,
   });
 }
 
@@ -153,13 +153,13 @@ export function assertDocumentDetailPageAChanges(resp: CustomFileResponses) {
     {
       type: TYPES.DE?.name,
       fullName: FULL_NAMES.DE_VIEW_DOCUMENT_DETAIL_A,
-      filePath: FILE_RELATIVE_PATHS.DE_VIEW_DOCUMENT_DETAIL_COMPONENT_A,
+      filePath: FILE_RELATIVE_PATHS.DE_VIEW_DOCUMENT_DETAIL_META_A,
     },
 
     {
       type: TYPES.DE?.name,
       fullName: FULL_NAMES.DE_ROUTE_DOCUMENT_DETAIL_A,
-      filePath: FILE_RELATIVE_PATHS.DE_ROUTE_DOCUMENT_DETAIL_COMPONENT_A,
+      filePath: FILE_RELATIVE_PATHS.DE_ROUTE_DOCUMENT_DETAIL_META_A,
     },
   ]);
   expect(resp).to.have.length(2);


### PR DESCRIPTION
### What does this PR do?

Corrects the expectation for preview command when DigitalExperience component files are added/deleted/changed. 

**preview** command shows the metafile path, unlike the **status** command showing individual content file paths.

### What issues does this PR fix or reference?

[@W-12965438@](https://gus.lightning.force.com/a07EE00001OS9AAYA1)
