### PR TITLE
fix: can report on a async mdapi format deploy

### DIFF
--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -61,9 +61,13 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
       // we'll use whatever the org supports since we can't specify the org
       // eslint-disable-next-line sf-plugin/get-connection-with-version
       org.getConnection().metadata.checkDeployStatus(jobId, true),
-      buildComponentSet({ ...deployOpts, wait: Duration.minutes(deployOpts.wait) }),
+      // if we're using mdapi, we won't have a component set
+      deployOpts.isMdapi ? undefined : buildComponentSet({ ...deployOpts, wait: Duration.minutes(deployOpts.wait) }),
     ]);
 
+    // @ts-expect-error sdr/DeployResult handles undefined componentSet.
+    // The strict - null - check branch changes this to explicitly allow undefined.
+    // expect-error can be removed once that merges
     const result = new DeployResult(deployStatus as MetadataApiDeployStatus, componentSet);
 
     const formatter = new DeployReportResultFormatter(result, {

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -59,6 +59,8 @@ export type DeployOptions = {
 /** Manifest is expected.  You cannot pass metadata and source-dir array--use those to get a manifest */
 export type CachedOptions = Omit<DeployOptions, 'wait' | 'metadata' | 'source-dir'> & {
   wait: number;
+  /** whether the user passed in anything for metadata-dir (could be a folder, could be a zip) */
+  isMdapi: boolean;
 } & Partial<Pick<DeployOptions, 'manifest'>>;
 
 export function validateTests(testLevel: TestLevel, tests: Nullable<string[]>): boolean {

--- a/src/utils/deployCache.ts
+++ b/src/utils/deployCache.ts
@@ -33,9 +33,9 @@ export class DeployCache extends TTLConfig<TTLConfig.Options, CachedOptions> {
    */
   public static async set(key: string, value: Partial<DeployOptions>): Promise<void> {
     const cache = await DeployCache.create();
-    // remove properties we won't cache
+    // remove properties we won't cache or that are not primitives
     const { 'metadata-dir': mdDir, 'source-dir': sourceDir, wait, ...cleanValue } = value;
-    cache.set(key, { ...cleanValue, wait: wait?.minutes ?? 33 });
+    cache.set(key, { ...cleanValue, wait: wait?.minutes ?? 33, isMdapi: Boolean(mdDir) });
     await cache.write();
   }
 


### PR DESCRIPTION
### What does this PR do?
to replicate the gh issue, you
1. convert project do mdapi format
2. deploy that using `project deploy start` with `--metadata-dir`

The error is coming from SDR componentSetBuilder because mdapi format deployments don't use componentSet.

This PR
1. adds a `isMdapi` boolean to the DeployCache records, which is "true" whenever metada-dir is given
2. skips the componentSet stuff when`isMdapi` is in the retrieved deployCache record
 
### What issues does this PR fix or reference?
[@W-12992462@](https://github.com/forcedotcom/cli/issues/2046)
