### PR TITLE
fix: testresult mapping of source deployment

### DIFF
--- a/src/utils/coverage.ts
+++ b/src/utils/coverage.ts
@@ -27,8 +27,8 @@ export const mapTestResults = <T extends Failures | Successes>(testResults: T[])
     fullName: testResult.name,
     id: testResult.id,
     ...('message' in testResult && testResult.message
-      ? { message: testResult.message, outcome: ApexTestResultOutcome.Pass }
-      : { message: null, outcome: ApexTestResultOutcome.Fail }),
+      ? { message: testResult.message, outcome: ApexTestResultOutcome.Fail }
+      : { message: null, outcome: ApexTestResultOutcome.Pass }),
     methodName: testResult.methodName,
     queueItemId: '',
     runTime: parseInt(testResult.time, 10),

--- a/test/utils/coverage.test.ts
+++ b/test/utils/coverage.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from 'chai';
+import { ApexTestResultOutcome } from '@salesforce/apex-node';
+import { mapTestResults } from '../../src/utils/coverage';
+
+describe('coverage utils', () => {
+  describe('mapTestResultsTests', () => {
+    it('should map result without a message to a succeeded test', () => {
+      const resultsArray = mapTestResults([
+        {
+          id: 'myId',
+          methodName: 'mySuccessMethod',
+          name: 'myName',
+          time: '42',
+        },
+      ]);
+      expect(resultsArray).to.have.length(1);
+
+      const result = resultsArray[0];
+
+      expect(result.outcome).to.be.eq(ApexTestResultOutcome.Pass);
+      expect(result.message).to.be.null;
+      expect(result.fullName).to.be.eq('myName');
+      expect(result.methodName).to.be.eq('mySuccessMethod');
+      expect(result.runTime).to.be.eq(42);
+    });
+
+    it('should map result with a message to a failed test', () => {
+      const resultsArray = mapTestResults([
+        {
+          id: 'myId',
+          methodName: 'myFailedMethod',
+          name: 'myName',
+          time: '42',
+          message: 'Something went wrong',
+          stackTrace: 'SomeStackTrace',
+        },
+      ]);
+      expect(resultsArray).to.have.length(1);
+
+      const result = resultsArray[0];
+
+      expect(result.outcome).to.be.eq(ApexTestResultOutcome.Fail);
+      expect(result.message).to.be.eq('Something went wrong');
+      expect(result.fullName).to.be.eq('myName');
+      expect(result.methodName).to.be.eq('myFailedMethod');
+      expect(result.runTime).to.be.eq(42);
+      expect(result.stackTrace).to.be.eq('SomeStackTrace');
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

@W-13048665@

The `mapTestResults` method is used by [`DeployResultFormatter`](https://github.com/salesforcecli/plugin-deploy-retrieve/blob/9e79c4024cdf75078c95ce8bcc0c449e31363561/src/formatters/deployResultFormatter.ts#L153) to map the nested test-results of a deployment-result into `ApexTestResultData` objects, which are later used to generate a JUnit test report. Commit https://github.com/salesforcecli/plugin-deploy-retrieve/commit/cdc8f6e615f4cfa9c5accaf6c420bc2333258c78 introduces a bug which is mapping test results without a `message` property to a failed test and vice versa. 

This PR switches the logic back to the original one.

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2076

### Context info

This is a JSON example for a succeeded test retrieved via deploy API:

```json
{
          "namespace" : null,
          "name" : "MyTest",
          "methodName" : "myTestMethod",
          "id" : "<SOME ID>",
          "time" : 384.0,
          "seeAllData" : null
}
```

while this is a failed one:

```json
{
          "type" : "Class",
          "namespace" : null,
          "name" : "MyFailingTest",
          "methodName" : "myTestMethodFailing",
          "message" : "System.DmlException: Update failed. First exception on row 1 with id <ID>; first error: INVALID_CROSS_REFERENCE_KEY, invalid cross reference id: []",
          "stackTrace" : "Class.SomeClass.SomeMethod: line 184, column 1[...]",
          "id" : "<SOME ID>",
          "seeAllData" : null,
          "time" : 3063.0,
          "packageName" : "SomePackage"
        }
```