### PR TITLE
feat: default undefined test-level when not doing validate

### DIFF
--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -32,7 +32,7 @@ import {
   SfCommand,
 } from '@salesforce/sf-plugins-core';
 import * as chalk from 'chalk';
-import { DeleteSourceJson, TestLevel, isSourceComponent } from '../../../utils/types';
+import { DeleteSourceJson, isSourceComponent } from '../../../utils/types';
 import { getPackageDirs, getSourceApiVersion } from '../../../utils/project';
 import { resolveApi } from '../../../utils/deploy';
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter';
@@ -77,7 +77,6 @@ export class Source extends SfCommand<DeleteSourceJson> {
       description: messages.getMessage('flags.test-Level.description'),
       summary: messages.getMessage('flags.test-Level.summary'),
       options: ['NoTestRun', 'RunLocalTests', 'RunAllTestsInOrg'],
-      default: TestLevel.NoTestRun,
     }),
     'no-prompt': Flags.boolean({
       char: 'r',

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -112,7 +112,6 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       description: messages.getMessage('flags.tests.description'),
     }),
     'test-level': testLevelFlag({
-      default: TestLevel.NoTestRun,
       description: messages.getMessage('flags.test-level.description'),
       summary: messages.getMessage('flags.test-level.summary'),
       options: [TestLevel.NoTestRun, TestLevel.RunSpecifiedTests, TestLevel.RunLocalTests, TestLevel.RunAllTestsInOrg],

--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -33,7 +33,7 @@ import { sortFileResponses, asRelativePaths, tableHeader, getFileResponseSuccess
 export class DeployResultFormatter implements Formatter<DeployResultJson> {
   private relativeFiles: FileResponse[];
   private absoluteFiles: FileResponse[];
-  private testLevel: TestLevel;
+  private testLevel: TestLevel | undefined;
   private verbosity: Verbosity;
   private coverageOptions: CoverageReporterOptions;
   private resultsDir: string;
@@ -53,7 +53,7 @@ export class DeployResultFormatter implements Formatter<DeployResultJson> {
   ) {
     this.absoluteFiles = sortFileResponses(this.result.getFileResponses() ?? []);
     this.relativeFiles = asRelativePaths(this.absoluteFiles);
-    this.testLevel = this.flags['test-level'] ?? TestLevel.NoTestRun;
+    this.testLevel = this.flags['test-level'];
     this.verbosity = this.determineVerbosity();
     this.resultsDir = this.flags['results-dir'] ?? 'coverage';
     this.coverageOptions = getCoverageFormattersOptions(this.flags['coverage-formatters']);
@@ -268,7 +268,7 @@ export class DeployResultFormatter implements Formatter<DeployResultJson> {
   }
 
   private displayTestResults(): void {
-    if (this.testLevel === TestLevel.NoTestRun) {
+    if (this.testLevel === TestLevel.NoTestRun || !this.result.response.details.runTestResult) {
       ux.log();
       return;
     }
@@ -285,7 +285,7 @@ export class DeployResultFormatter implements Formatter<DeployResultJson> {
     const passing = this.result.response.numberTestsCompleted ?? 0;
     const failing = this.result.response.numberTestErrors ?? 0;
     const total = this.result.response.numberTestsTotal ?? 0;
-    const time = this.result.response.details.runTestResult?.totalTime ?? 0;
+    const time = this.result.response.details.runTestResult.totalTime ?? 0;
     ux.log(`Passing: ${passing}`);
     ux.log(`Failing: ${failing}`);
     ux.log(`Total: ${total}`);

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -63,7 +63,7 @@ export type CachedOptions = Omit<DeployOptions, 'wait' | 'metadata' | 'source-di
   isMdapi: boolean;
 } & Partial<Pick<DeployOptions, 'manifest'>>;
 
-export function validateTests(testLevel: TestLevel, tests: Nullable<string[]>): boolean {
+export function validateTests(testLevel: TestLevel | undefined, tests: Nullable<string[]>): boolean {
   return !(testLevel === TestLevel.RunSpecifiedTests && (tests ?? []).length === 0);
 }
 


### PR DESCRIPTION
### What does this PR do?

background

1. prod orgs require apex tests to run if the deployment contains any apex.  (you could deploy an object with some fields without test running
1. source:deploy and mdapi:deploy let you specify a testlevel or pass it to the mdapi undefined, which implies, "let the org decide if it needs to run tests or not".
1.project deploy start defaults that flag to NoTestRun .  To do a production deployment, you'd have to set it to RunAllTests or something because the mdapi rejects any prod deploy with NoTestRun even if there is no requirement that tests run.  :shrug-h:

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2078
@W-13176049@