### PR TITLE
fix: deploys don't require a project

### DIFF
--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -112,7 +112,6 @@ export async function executeDeploy(
   project?: SfProject,
   id?: string
 ): Promise<{ deploy: MetadataApiDeploy; componentSet?: ComponentSet }> {
-  project ??= await SfProject.resolve();
   const apiOptions = {
     checkOnly: opts['dry-run'] ?? false,
     ignoreWarnings: opts['ignore-warnings'] ?? false,
@@ -142,6 +141,8 @@ export async function executeDeploy(
       await deploy.start();
     }
   } else {
+    // mddapi format deploys don't require a project
+    project ??= await SfProject.resolve();
     // instantiate source tracking
     // stl will decide, based on the org's properties, what needs to be done
     const stl = await SourceTracking.create({


### PR DESCRIPTION
### What does this PR do?
deploys that use mdapi format don't require a project

### What issues does this PR fix or reference?
@W-13157990@
https://github.com/forcedotcom/cli/issues/2089
