### PR TITLE
fix: retrieve doesn't require STL or Project

### DIFF
--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -118,7 +118,6 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
       summary: messages.getMessage('flags.zip-file-name.summary'),
       dependsOn: ['target-metadata-dir'],
       exclusive: ['ignore-conflicts'],
-      default: DEFAULT_ZIP_FILE_NAME,
     }),
   };
 
@@ -175,7 +174,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
     const formatter = flags['target-metadata-dir']
       ? new MetadataRetrieveResultFormatter(result, {
           'target-metadata-dir': flags['target-metadata-dir'],
-          'zip-file-name': flags['zip-file-name'],
+          'zip-file-name': flags['zip-file-name'] ?? DEFAULT_ZIP_FILE_NAME,
           unzip: flags.unzip,
         })
       : new RetrieveResultFormatter(result, flags['package-name'], fileResponsesFromDelete);
@@ -192,7 +191,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
 
     if (format === 'metadata' && flags.unzip) {
       try {
-        await rm(resolve(join(flags['target-metadata-dir'] ?? '', flags['zip-file-name'])), {
+        await rm(resolve(join(flags['target-metadata-dir'] ?? '', flags['zip-file-name'] ?? DEFAULT_ZIP_FILE_NAME)), {
           recursive: true,
         });
       } catch (e) {
@@ -289,7 +288,7 @@ const buildRetrieveOptions = (
     ? {
         singlePackage: flags['single-package'],
         unzip: flags.unzip,
-        zipFileName: flags['zip-file-name'],
+        zipFileName: flags['zip-file-name'] ?? DEFAULT_ZIP_FILE_NAME,
         // known to exist because that's how `format` becomes 'metadata'
         output: flags['target-metadata-dir'] as string,
       }

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -8,13 +8,20 @@
 import { rm } from 'fs/promises';
 import { join, resolve } from 'path';
 
-import { EnvironmentVariable, Messages, OrgConfigProperties, SfError } from '@salesforce/core';
-import { RetrieveResult, ComponentSetBuilder, RetrieveSetOptions } from '@salesforce/source-deploy-retrieve';
-
+import { EnvironmentVariable, Messages, OrgConfigProperties, SfError, SfProject } from '@salesforce/core';
+import {
+  RetrieveResult,
+  ComponentSetBuilder,
+  RetrieveSetOptions,
+  ComponentSet,
+  FileResponse,
+} from '@salesforce/source-deploy-retrieve';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { getString } from '@salesforce/ts-types';
 import { SourceTracking, SourceConflictError } from '@salesforce/source-tracking';
 import { Duration } from '@salesforce/kit';
+import { Interfaces } from '@oclif/core';
+
 import { DEFAULT_ZIP_FILE_NAME, ensuredDirFlag, zipFileFlag } from '../../../utils/flags';
 import { RetrieveResultFormatter } from '../../../formatters/retrieveResultFormatter';
 import { MetadataRetrieveResultFormatter } from '../../../formatters/metadataRetrieveResultFormatter';
@@ -26,6 +33,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-deploy-retrieve', 'retrieve.metadata');
 const mdTransferMessages = Messages.loadMessages('@salesforce/plugin-deploy-retrieve', 'metadata.transfer');
 
+type Format = 'source' | 'metadata';
 export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
@@ -111,6 +119,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
       summary: messages.getMessage('flags.zip-file-name.summary'),
       dependsOn: ['target-metadata-dir'],
       exclusive: ['ignore-conflicts'],
+      default: DEFAULT_ZIP_FILE_NAME,
     }),
   };
 
@@ -127,65 +136,22 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
 
   protected retrieveResult!: RetrieveResult;
 
-  // eslint-disable-next-line complexity
   public async run(): Promise<RetrieveResultJson> {
     const { flags } = await this.parse(RetrieveMetadata);
+    const format: Format = flags['target-metadata-dir'] ? 'metadata' : 'source';
 
     this.spinner.start(messages.getMessage('spinner.start'));
-    const format = flags['target-metadata-dir'] ? 'metadata' : 'source';
-    const stl = await SourceTracking.create({
-      org: flags['target-org'],
-      project: this.project,
-      subscribeSDREvents: true,
-      ignoreConflicts: format === 'metadata' || flags['ignore-conflicts'],
-    });
-    const isChanges = !flags['source-dir'] && !flags['manifest'] && !flags['metadata'];
-    const { componentSetFromNonDeletes, fileResponsesFromDelete } = isChanges
-      ? await stl.maybeApplyRemoteDeletesToLocal(true)
-      : {
-          componentSetFromNonDeletes: await ComponentSetBuilder.build({
-            apiversion: flags['api-version'],
-            sourcepath: flags['source-dir'],
-            packagenames: flags['package-name'],
-            ...(flags.manifest
-              ? {
-                  manifest: {
-                    manifestPath: flags.manifest,
-                    directoryPaths: await getPackageDirs(),
-                  },
-                }
-              : {}),
-            ...(flags.metadata
-              ? { metadata: { metadataEntries: flags.metadata, directoryPaths: await getPackageDirs() } }
-              : {}),
-          }),
-          fileResponsesFromDelete: [],
-        };
-    // stl sets version based on config/files--if the command overrides it, we need to update
-    if (isChanges && flags['api-version']) {
-      componentSetFromNonDeletes.apiVersion = flags['api-version'];
-    }
+
+    const { componentSetFromNonDeletes, fileResponsesFromDelete = [] } = await buildRetrieveAndDeleteTargets(
+      flags,
+      this.project,
+      format
+    );
+    const retrieveOpts = buildRetrieveOptions(flags, this.project, format);
+
     this.spinner.status = messages.getMessage('spinner.sending', [
       componentSetFromNonDeletes.sourceApiVersion ?? componentSetFromNonDeletes.apiVersion,
     ]);
-
-    const zipFileName = flags['zip-file-name'] ?? DEFAULT_ZIP_FILE_NAME;
-    const retrieveOpts: RetrieveSetOptions = {
-      usernameOrConnection:
-        flags['target-org'].getUsername() ?? flags['target-org'].getConnection(flags['api-version']),
-      merge: true,
-      output: this.project.getDefaultPackage().fullPath,
-      packageOptions: flags['package-name'],
-      format,
-      ...(format === 'metadata'
-        ? {
-            singlePackage: flags['single-package'],
-            unzip: flags.unzip,
-            zipFileName,
-            output: flags['target-metadata-dir'],
-          }
-        : {}),
-    };
 
     const retrieve = await componentSetFromNonDeletes.retrieve(retrieveOpts);
 
@@ -194,12 +160,9 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
     retrieve.onUpdate((data) => {
       this.spinner.status = mdTransferMessages.getMessage(data.status);
     });
-
     // any thing else should stop the progress bar
     retrieve.onFinish((data) => this.spinner.stop(mdTransferMessages.getMessage(data.response.status)));
-
     retrieve.onCancel((data) => this.spinner.stop(mdTransferMessages.getMessage(data?.status ?? 'Canceled')));
-
     retrieve.onError((error: Error) => {
       this.spinner.stop(error.name);
       throw error;
@@ -213,7 +176,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
     const formatter = flags['target-metadata-dir']
       ? new MetadataRetrieveResultFormatter(result, {
           'target-metadata-dir': flags['target-metadata-dir'],
-          'zip-file-name': zipFileName,
+          'zip-file-name': flags['zip-file-name'],
           unzip: flags.unzip,
         })
       : new RetrieveResultFormatter(result, flags['package-name'], fileResponsesFromDelete);
@@ -230,7 +193,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
 
     if (format === 'metadata' && flags.unzip) {
       try {
-        await rm(resolve(join(flags['target-metadata-dir'] ?? '', zipFileName)), {
+        await rm(resolve(join(flags['target-metadata-dir'] ?? '', flags['zip-file-name'])), {
           recursive: true,
         });
       } catch (e) {
@@ -242,17 +205,95 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
   }
 
   protected catch(error: Error | SfError): Promise<SfCommand.Error> {
-    if (error instanceof SourceConflictError) {
-      if (!this.jsonEnabled()) {
-        writeConflictTable(error.data);
-        // set the message and add plugin-specific actions
-        return super.catch({
-          ...error,
-          message: messages.getMessage('error.Conflicts'),
-          actions: messages.getMessages('error.Conflicts.Actions', [this.config.bin]),
-        });
-      }
+    if (!this.jsonEnabled() && error instanceof SourceConflictError) {
+      writeConflictTable(error.data);
+      // set the message and add plugin-specific actions
+      return super.catch({
+        ...error,
+        message: messages.getMessage('error.Conflicts'),
+        actions: messages.getMessages('error.Conflicts.Actions', [this.config.bin]),
+      });
     }
+
     return super.catch(error);
   }
 }
+
+type RetrieveAndDeleteTargets = {
+  /** componentSet that can be used to retrieve known changes */
+  componentSetFromNonDeletes: ComponentSet;
+  /** optional Array of artificially constructed FileResponses from the deletion of local files */
+  fileResponsesFromDelete?: FileResponse[];
+};
+
+const buildRetrieveAndDeleteTargets = async (
+  flags: Interfaces.InferredFlags<typeof RetrieveMetadata.flags>,
+  project: SfProject,
+  format: Format
+): Promise<RetrieveAndDeleteTargets> => {
+  const isChanges = !flags['source-dir'] && !flags['manifest'] && !flags['metadata'];
+
+  if (isChanges) {
+    const stl = await SourceTracking.create({
+      org: flags['target-org'],
+      project,
+      subscribeSDREvents: true,
+      ignoreConflicts: format === 'metadata' || flags['ignore-conflicts'],
+    });
+    const result = await stl.maybeApplyRemoteDeletesToLocal(true);
+    // STL returns a componentSet that gets these from the project/config.
+    // if the command has a flag, we'll override
+    if (flags['api-version']) {
+      result.componentSetFromNonDeletes.apiVersion = flags['api-version'];
+    }
+  }
+
+  return {
+    componentSetFromNonDeletes: await ComponentSetBuilder.build({
+      apiversion: flags['api-version'],
+      sourcepath: flags['source-dir'],
+      packagenames: flags['package-name'],
+      ...(flags.manifest
+        ? {
+            manifest: {
+              manifestPath: flags.manifest,
+              directoryPaths: await getPackageDirs(),
+            },
+          }
+        : {}),
+      ...(flags.metadata
+        ? { metadata: { metadataEntries: flags.metadata, directoryPaths: await getPackageDirs() } }
+        : {}),
+    }),
+  };
+};
+
+/**
+ *
+ *
+ * @param flags
+ * @param project
+ * @param format 'metadata' or 'source'
+ * @returns RetrieveSetOptions (an object that can be passed as the options for a ComponentSet retrieve)
+ */
+const buildRetrieveOptions = (
+  flags: Interfaces.InferredFlags<typeof RetrieveMetadata.flags>,
+  project: SfProject,
+  format: Format
+): RetrieveSetOptions => ({
+  usernameOrConnection: flags['target-org'].getUsername() ?? flags['target-org'].getConnection(flags['api-version']),
+  merge: true,
+  packageOptions: flags['package-name'],
+  format,
+  ...(format === 'metadata'
+    ? {
+        singlePackage: flags['single-package'],
+        unzip: flags.unzip,
+        zipFileName: flags['zip-file-name'],
+        // known to exist because that's how `format` becomes 'metadata'
+        output: flags['target-metadata-dir'] as string,
+      }
+    : {
+        output: project.getDefaultPackage().fullPath,
+      }),
+});

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -38,7 +38,6 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
-  public static readonly requiresProject = true;
   public static readonly aliases = ['retrieve:metadata'];
   public static readonly deprecateAliases = true;
 
@@ -257,7 +256,8 @@ const buildRetrieveAndDeleteTargets = async (
         ? {
             manifest: {
               manifestPath: flags.manifest,
-              directoryPaths: await getPackageDirs(),
+              // if mdapi format, there might not be a project
+              directoryPaths: format === 'metadata' ? [] : await getPackageDirs(),
             },
           }
         : {}),

--- a/test/nuts/retrieve/noProject.ts
+++ b/test/nuts/retrieve/noProject.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as fs from 'fs';
+import { join } from 'path';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { assert, expect } from 'chai';
+import { RetrieveResultJson } from '../../../src/utils/types';
+
+const packageXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>ConnectedApp</name>
+    </types>
+    <version>56.0</version>
+</Package>
+`;
+
+describe('retrieve mdapi format without project', () => {
+  const packageFile = 'package.xml';
+  let xmlPath: string | undefined;
+  let session: TestSession;
+  before(async () => {
+    session = await TestSession.create({
+      devhubAuthStrategy: 'AUTO',
+    });
+    assert(session.hubOrg.username);
+    xmlPath = join(session.dir, packageFile);
+    await fs.promises.writeFile(xmlPath, packageXml);
+  });
+
+  it('can retrieve without a project', () => {
+    const outputDir = 'mdapiOut';
+    const result = execCmd<RetrieveResultJson>(
+      `project:retrieve:start -o ${session.hubOrg.username} --target-metadata-dir ${outputDir} -x ${xmlPath} --json`,
+      {
+        ensureExitCode: 0,
+      }
+    ).jsonOutput?.result;
+    // hub should have a connected app!
+    expect(result?.files).to.not.be.empty;
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+});

--- a/test/nuts/retrieve/noTracking.ts
+++ b/test/nuts/retrieve/noTracking.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as fs from 'fs';
+import { join } from 'path';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { assert, expect } from 'chai';
+import { RetrieveResultJson } from '../../../src/utils/types';
+
+const packageXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>ConnectedApp</name>
+    </types>
+    <version>56.0</version>
+</Package>
+`;
+
+describe('retrieve mdapi format without project', () => {
+  const packageFile = 'package.xml';
+  let xmlPath: string | undefined;
+  let session: TestSession;
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        name: 'hasProjectNoTracking',
+      },
+      devhubAuthStrategy: 'AUTO',
+    });
+    assert(session.hubOrg.username);
+    xmlPath = join(session.project.dir, packageFile);
+    await fs.promises.writeFile(xmlPath, packageXml);
+  });
+
+  it('can retrieve using a project with a non-tracking org', () => {
+    const outputDir = 'mdapiOut';
+    const result = execCmd<RetrieveResultJson>(
+      `project:retrieve:start -o ${session.hubOrg.username} --target-metadata-dir ${outputDir} -x ${xmlPath} --json`,
+      {
+        ensureExitCode: 0,
+      }
+    ).jsonOutput?.result;
+    // hub should have a connected app but not have tracking on
+    expect(result?.files).to.not.be.empty;
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+});


### PR DESCRIPTION
### What does this PR do?
- defer STL instantiation to fix the stated bug
- avoid calling methods on SfProject during mdapi retrieves   

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2091
@W-13139200@