### PR TITLE
fix: print errors from server

### DIFF
--- a/test/utils/output.test.ts
+++ b/test/utils/output.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { assert, expect, config } from 'chai';
 import * as sinon from 'sinon';
 import { DeployResult } from '@salesforce/source-deploy-retrieve';
+import { ux } from '@oclif/core';
 import { getCoverageFormattersOptions } from '../../src/utils/coverage';
 import { DeployResultFormatter } from '../../src/formatters/deployResultFormatter';
 import { getDeployResult } from './deployResponses';
@@ -19,6 +20,29 @@ describe('deployResultFormatter', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  describe('displayFailures', () => {
+    const deployResultFailure = getDeployResult('failed');
+    const tableStub = sandbox.stub(ux, 'table');
+
+    it('prints file responses, and messages from server', () => {
+      const formatter = new DeployResultFormatter(deployResultFailure, { verbose: true });
+      formatter.display();
+      expect(tableStub.callCount).to.equal(1);
+      expect(tableStub.firstCall.args[0]).to.deep.equal([
+        {
+          error: 'This component has some problems',
+          fullName: 'ProductController',
+          problemType: 'Error',
+        },
+        {
+          error: 'This component has some problems',
+          fullName: 'ProductController',
+          problemType: 'Error',
+        },
+      ]);
+    });
   });
 
   describe('coverage functions', () => {


### PR DESCRIPTION
### What does this PR do?

prints errors reported by the server that were missed from `.getFileResponses`
before
```
 ➜  ../../oss/plugin-deploy-retrieve/bin/dev project:deploy:start                                                     
*** Deploying with SOAP API v57.0 ***
Deploy ID: 0AfDR00002Z1Q1i0AF
Status: Failed | ████████████████████████████████████████ | 3/3 Components

```

after
```
 ➜  ../../oss/plugin-deploy-retrieve/bin/dev project:deploy:start
*** Deploying with SOAP API v57.0 ***
Deploy ID: 0AfDR00002Z1Rxo0AF
Status: Failed | ████████████████████████████████████████ | 3/3 Components

Component Failures [1]
===================================================================
| Type  Name                               Problem                  
| ───── ────────────────────────────────── ──────────────────────── 
| Error classes/FileUtilities.cls-meta.xml Invalid api version:88.0 
```
### What issues does this PR fix or reference?
@W-12727451@
https://github.com/forcedotcom/cli/issues/2008