### PR TITLE
fix: stacktrace can by null (is typed wrong)

### DIFF
--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -314,10 +314,12 @@ export class DeployResultFormatter implements Formatter<DeployResultJson> {
     ux.log(error(`Test Failures [${failureCount}]`));
     for (const test of testFailures) {
       const testName = underline(`${test.name}.${test.methodName}`);
-      const stackTrace = test.stackTrace.replace(/\n/g, `${os.EOL}    `);
       ux.log(`• ${testName}`);
       ux.log(`  ${dim('message')}: ${test.message}`);
-      ux.log(`  ${dim('stacktrace')}: ${os.EOL}    ${stackTrace}`);
+      if (test.stackTrace) {
+        const stackTrace = test.stackTrace.replace(/\n/g, `${os.EOL}    `);
+        ux.log(`  ${dim('stacktrace')}: ${os.EOL}    ${stackTrace}`);
+      }
       ux.log();
     }
   }


### PR DESCRIPTION
### What does this PR do?
handle null stacktrace

### What issues does this PR fix or reference?
[@W-13481008@](https://gus.lightning.force.com/a07EE00001SBsUJYA1)
https://github.com/forcedotcom/cli/issues/2149