### PR TITLE
fix: display correct api version

### DIFF
--- a/messages/deploy.metadata.md
+++ b/messages/deploy.metadata.md
@@ -230,3 +230,7 @@ You requested an async deploy with code coverage or JUnit results. The reports w
 # pushPackageDirsWarning
 
 The `pushPackageDirectoriesSequentially` property is not respected by this command. Please call the `project deploy start --source-dir` command for each dependency in the correct order.
+
+# apiVersionMsgDetailed
+
+%s v%s metadata to %s using the v%s %s API.

--- a/messages/retrieve.start.md
+++ b/messages/retrieve.start.md
@@ -180,3 +180,7 @@ Directory root for the retrieved source files.
 # retrieveTargetDirOverlapsPackage
 
 The retrieve target directory [%s] overlaps one of your package directories. Specify a different retrieve target directory and try again.
+
+# apiVersionMsgDetailed
+
+%s v%s metadata from %s using the v%s SOAP API

--- a/src/commands/project/deploy/cancel.ts
+++ b/src/commands/project/deploy/cancel.ts
@@ -35,6 +35,7 @@ export default class DeployMetadataCancel extends SfCommand<DeployResultJson> {
     'job-id': Flags.salesforceId({
       char: 'i',
       startsWith: '0Af',
+      length: 'both',
       description: messages.getMessage('flags.job-id.description'),
       summary: messages.getMessage('flags.job-id.summary'),
       exactlyOne: ['use-most-recent', 'job-id'],

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -13,7 +13,6 @@ import { Duration } from '@salesforce/kit';
 import { buildComponentSet, DeployOptions, determineExitCode, poll, resolveApi } from '../../../utils/deploy';
 import { DeployCache } from '../../../utils/deployCache';
 import { DEPLOY_STATUS_CODES_DESCRIPTIONS } from '../../../utils/errorCodes';
-import { getVersionMessage } from '../../../utils/output';
 import { AsyncDeployResultFormatter } from '../../../formatters/asyncDeployResultFormatter';
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter';
 import { DeployResultJson } from '../../../utils/types';
@@ -42,6 +41,7 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
     'job-id': Flags.salesforceId({
       char: 'i',
       startsWith: '0Af',
+      length: 'both',
       description: messages.getMessage('flags.job-id.description'),
       summary: messages.getMessage('flags.job-id.summary'),
       exactlyOne: ['use-most-recent', 'job-id'],
@@ -92,7 +92,6 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
 
     await org.getConnection(flags['api-version']).metadata.deployRecentValidation({ id: jobId, rest: api === 'REST' });
     const componentSet = await buildComponentSet({ ...deployOpts, wait: flags.wait });
-    this.log(getVersionMessage('Deploying', componentSet, api));
     this.log(`Deploy ID: ${bold(jobId)}`);
 
     if (flags.async) {

--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -30,6 +30,7 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
     'job-id': Flags.salesforceId({
       char: 'i',
       startsWith: '0Af',
+      length: 'both',
       description: messages.getMessage('flags.job-id.description'),
       summary: messages.getMessage('flags.job-id.summary'),
       exactlyOne: ['use-most-recent', 'job-id'],

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -9,7 +9,6 @@ import { bold } from 'chalk';
 import { EnvironmentVariable, Messages, SfError } from '@salesforce/core';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { Duration } from '@salesforce/kit';
-import { getVersionMessage } from '../../../utils/output';
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter';
 import { DeployProgress } from '../../../utils/progressBar';
 import { DeployResultJson } from '../../../utils/types';
@@ -37,6 +36,7 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
     'job-id': Flags.salesforceId({
       char: 'i',
       startsWith: '0Af',
+      length: 'both',
       description: messages.getMessage('flags.job-id.description'),
       summary: messages.getMessage('flags.job-id.summary'),
       exactlyOne: ['use-most-recent', 'job-id'],
@@ -85,7 +85,7 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
     }
 
     const wait = flags.wait ?? Duration.minutes(deployOpts.wait);
-    const { deploy, componentSet } = await executeDeploy(
+    const { deploy } = await executeDeploy(
       // there will always be conflicts on a resume if anything deployed--the changes on the server are not synced to local
       { ...deployOpts, wait, 'dry-run': false, 'ignore-conflicts': true },
       this.config.bin,
@@ -93,7 +93,6 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
       jobId
     );
 
-    this.log(getVersionMessage('Resuming Deployment', componentSet, deployOpts.api));
     this.log(`Deploy ID: ${bold(jobId)}`);
     new DeployProgress(deploy, this.jsonEnabled()).start();
 

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -5,10 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { bold } from 'chalk';
-import { EnvironmentVariable, Messages, OrgConfigProperties, SfError } from '@salesforce/core';
+import { EnvironmentVariable, Lifecycle, Messages, OrgConfigProperties, SfError } from '@salesforce/core';
+import { DeployVersionData } from '@salesforce/source-deploy-retrieve';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { SourceConflictError } from '@salesforce/source-tracking';
-import { getVersionMessage } from '../../../utils/output';
 import { AsyncDeployResultFormatter } from '../../../formatters/asyncDeployResultFormatter';
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter';
 import { DeployProgress } from '../../../utils/progressBar';
@@ -199,10 +199,26 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
     }
 
     const api = await resolveApi(this.configAggregator);
-    const { deploy, componentSet } = await executeDeploy(
+    const username = flags['target-org'].getUsername();
+    const action = flags['dry-run'] ? 'Deploying (dry-run)' : 'Deploying';
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    Lifecycle.getInstance().on('apiVersionDeploy', async (apiData: DeployVersionData) => {
+      this.log(
+        messages.getMessage('apiVersionMsgDetailed', [
+          action,
+          apiData.manifestVersion,
+          username,
+          apiData.apiVersion,
+          apiData.webService,
+        ])
+      );
+    });
+
+    const { deploy } = await executeDeploy(
       {
         ...flags,
-        'target-org': flags['target-org'].getUsername(),
+        'target-org': username,
         api,
       },
       this.config.bin,
@@ -214,8 +230,6 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       return { status: 'Nothing to deploy', files: [] };
     }
 
-    const action = flags['dry-run'] ? 'Deploying (dry-run)' : 'Deploying';
-    this.log(getVersionMessage(action, componentSet, api));
     if (!deploy.id) {
       throw new SfError('The deploy id is not available.');
     }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -7,13 +7,7 @@
 
 import * as path from 'path';
 import { blue, bold } from 'chalk';
-import {
-  ComponentSet,
-  FileResponse,
-  FileResponseFailure,
-  FileResponseSuccess,
-} from '@salesforce/source-deploy-retrieve';
-import { API } from './types';
+import { FileResponse, FileResponseFailure, FileResponseSuccess } from '@salesforce/source-deploy-retrieve';
 
 export function tableHeader(message: string): string {
   return blue(bold(message));
@@ -43,27 +37,6 @@ export function sortFileResponses<T extends FileResponse | FileResponseSuccess |
     }
     return i.type > j.type ? 1 : -1;
   });
-}
-
-export function getVersionMessage(action: string, componentSet: ComponentSet | undefined, api: API): string {
-  // commands pass in the.componentSet, which may not exist in some tests or mdapi deploys
-  if (!componentSet) {
-    return `*** ${action} with ${api} ***`;
-  }
-  // neither
-  if (!componentSet.sourceApiVersion && !componentSet.apiVersion) {
-    return `*** ${action} with ${api} ***`;
-  }
-  // either OR both match (SDR will use either)
-  if (
-    !componentSet.sourceApiVersion ||
-    !componentSet.apiVersion ||
-    componentSet.sourceApiVersion === componentSet.apiVersion
-  ) {
-    return `*** ${action} with ${api} API v${componentSet.apiVersion ?? componentSet.sourceApiVersion} ***`;
-  }
-  // has both but they don't match
-  return `*** ${action} v${componentSet.sourceApiVersion} metadata with ${api} API v${componentSet.apiVersion} connection ***`;
 }
 
 export const getFileResponseSuccessProps = (


### PR DESCRIPTION
### What does this PR do?
This changes the various deploy and retrieve commands to listen to the event fired from the SDR library to output the correct sourceApiVersion and apiVersion used when making those requests.  There are certain scenarios where the plugin doesn't have all the necessary data at the appropriate time to handle it and display a correct message.

NOTE: this changes some of the commands to not report the apiVersion message because they are only polling for results or using a jsforce API directly.  The commands are: `deploy quick`, `deploy report`, and `deploy resume`.  These commands are simply reporting or continuing deploy requests that were already made so displaying the apiVersion message is not super important.

### What issues does this PR fix or reference?
@W-13223973@