### PR TITLE
fix: allow mdapi --dry-runs to be quick deploy'd if valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
       "output": []
     },
     "test:command-reference": {
-      "command": "\"./bin/dev\" commandreference:generate --erroronwarnings",
+      "command": "\"./bin/dev\" commandreference:generate --error-on-warnings",
       "files": [
         "src/**/*.ts",
         "messages/**",

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -10,7 +10,7 @@ import { Messages, Org } from '@salesforce/core';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { RequestStatus } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
-import { buildComponentSet, DeployOptions, determineExitCode, poll, resolveApi } from '../../../utils/deploy';
+import { DeployOptions, determineExitCode, poll, resolveApi } from '../../../utils/deploy';
 import { DeployCache } from '../../../utils/deployCache';
 import { DEPLOY_STATUS_CODES_DESCRIPTIONS } from '../../../utils/errorCodes';
 import { AsyncDeployResultFormatter } from '../../../formatters/asyncDeployResultFormatter';
@@ -91,7 +91,6 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
     const api = await resolveApi(this.configAggregator);
 
     await org.getConnection(flags['api-version']).metadata.deployRecentValidation({ id: jobId, rest: api === 'REST' });
-    const componentSet = await buildComponentSet({ ...deployOpts, wait: flags.wait });
     this.log(`Deploy ID: ${bold(jobId)}`);
 
     if (flags.async) {
@@ -100,8 +99,7 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
       return asyncFormatter.getJson();
     }
 
-    const result = await poll(org, jobId, flags.wait, componentSet);
-
+    const result = await poll(org, jobId, flags.wait);
     const formatter = new DeployResultFormatter(result, flags);
 
     if (!this.jsonEnabled()) formatter.display();

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -219,10 +219,10 @@ export async function cancelDeployAsync(opts: Partial<DeployOptions>, id: string
   return { id: deploy.id };
 }
 
-export async function poll(org: Org, id: string, wait: Duration, componentSet: ComponentSet): Promise<DeployResult> {
+export async function poll(org: Org, id: string, wait: Duration, componentSet?: ComponentSet): Promise<DeployResult> {
   const report = async (): Promise<DeployResult> => {
     const res = await org.getConnection().metadata.checkDeployStatus(id, true);
-    const deployStatus = res as unknown as MetadataApiDeployStatus;
+    const deployStatus = res as MetadataApiDeployStatus;
     return new DeployResult(deployStatus, componentSet);
   };
 
@@ -238,7 +238,7 @@ export async function poll(org: Org, id: string, wait: Duration, componentSet: C
     },
   };
   const pollingClient = await PollingClient.create(opts);
-  return pollingClient.subscribe() as unknown as Promise<DeployResult>;
+  return pollingClient.subscribe();
 }
 
 export function determineExitCode(result: DeployResult, async = false): number {


### PR DESCRIPTION
### What does this PR do?
When a `--metadata-dir --dry-run` deploy was subsequentally `deploy quick`'d it would fail when creating a component set to print the results for

the `componentSet` parameter was optional where it was used, so removed need for a CS when `deploy quick`

### What issues does this PR fix or reference?
@W-13131279@
https://github.com/forcedotcom/cli/issues/2098