### PR TITLE
fix: remove API version from spinner

### DIFF
--- a/messages/retrieve.start.md
+++ b/messages/retrieve.start.md
@@ -143,7 +143,7 @@ Preparing retrieve request
 
 # spinner.sending
 
-Sending request to org (metadata API version %s)
+Sending request to org
 
 # spinner.polling
 

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -185,7 +185,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
     this.spinner.status = messages.getMessage('spinner.sending', [
       componentSetFromNonDeletes.sourceApiVersion ??
         componentSetFromNonDeletes.apiVersion ??
-        flags['target-org'].getConnection().getApiVersion(),
+        flags['target-org'].getConnection().getApiVersion(), // eslint-disable-line sf-plugin/get-connection-with-version
     ]);
 
     this.retrieveResult = new RetrieveResult({} as MetadataApiRetrieveStatus, componentSetFromNonDeletes);

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -183,7 +183,9 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
     const retrieveOpts = await buildRetrieveOptions(flags, format, zipFileName, resolvedTargetDir);
 
     this.spinner.status = messages.getMessage('spinner.sending', [
-      componentSetFromNonDeletes.sourceApiVersion ?? componentSetFromNonDeletes.apiVersion,
+      componentSetFromNonDeletes.sourceApiVersion ??
+        componentSetFromNonDeletes.apiVersion ??
+        flags['target-org'].getConnection().getApiVersion(),
     ]);
 
     this.retrieveResult = new RetrieveResult({} as MetadataApiRetrieveStatus, componentSetFromNonDeletes);

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -182,11 +182,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
     );
     const retrieveOpts = await buildRetrieveOptions(flags, format, zipFileName, resolvedTargetDir);
 
-    this.spinner.status = messages.getMessage('spinner.sending', [
-      componentSetFromNonDeletes.sourceApiVersion ??
-        componentSetFromNonDeletes.apiVersion ??
-        flags['target-org'].getConnection().getApiVersion(), // eslint-disable-line sf-plugin/get-connection-with-version
-    ]);
+    this.spinner.status = messages.getMessage('spinner.sending');
 
     this.retrieveResult = new RetrieveResult({} as MetadataApiRetrieveStatus, componentSetFromNonDeletes);
 


### PR DESCRIPTION
### What does this PR do?
Removes API version from spinner msg in `project retrieve start` command.

### What issues does this PR fix or reference?
[skip-validate-pr]