### PR TITLE
fix: throw if delete request is canceled

### DIFF
--- a/messages/delete.source.md
+++ b/messages/delete.source.md
@@ -135,6 +135,10 @@ Are you sure you want to proceed (this is only a check and won't actually delete
 
 We couldn't complete the operation due to conflicts. Verify that you want to keep the existing versions, then run the command again with the --force-overwrite (-f) option.
 
+# prompt.delete.cancel
+
+The request to delete metadata was canceled.
+
 # error.NoTestsSpecified
 
 You must specify tests using the --tests flag if the --test-level flag is set to RunSpecifiedTests.

--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -224,7 +224,9 @@ export class Source extends SfCommand<DeleteSourceJson> {
     }
 
     this.aborted = !(await this.handlePrompt());
-    if (this.aborted) return;
+    if (this.aborted) {
+      throw messages.createError('prompt.delete.cancel');
+    }
 
     // fire predeploy event for the delete
     await Lifecycle.getInstance().emit('predeploy', this.components);


### PR DESCRIPTION
### What does this PR do?
Makes `project delete source` throw an error if the user answers `no` when asking for confirmation.

### before
```
➜  dreamhouse-lwc git:(main) echo no | sf project delete source --metadata ApexClass:GeocodingService
?

This operation will delete the following files on your computer and in your org:
/Users/cdominguez/code/gh/dreamhouse-lwc/force-app/main/default/classes/GeocodingService.cls-meta.xml
/Users/cdominguez/code/gh/dreamhouse-lwc/force-app/main/default/classes/GeocodingService.cls
Are you sure you want to proceed? No
Error (1): Cannot read properties of undefined (reading 'response')
```

### after
```
➜  dreamhouse-lwc git:(main) echo no | ../sf/plugin-deploy-retrieve/bin/dev project:delete:source --metadata ApexClass:GeocodingService
?

This operation will delete the following files on your computer and in your org:
/Users/cdominguez/code/gh/dreamhouse-lwc/force-app/main/default/classes/GeocodingService.cls-meta.xml
/Users/cdominguez/code/gh/dreamhouse-lwc/force-app/main/default/classes/GeocodingService.cls
Are you sure you want to proceed? No
Error (1): The request to delete metadata was canceled.
```

QA suggestion:
1) create a scratch org and deploy dreamhouse
2) try to delete any MD, example:
`sf project delete source --metadata ApexClass:GeocodingService`
then type `no` and <kbd>Enter</kbd>
3) should get `Error (1): Cannot read properties of undefined (reading 'response')`

### What issues does this PR fix or reference?
[@W-13709284@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001VRHoZYAX/view)