### PR TITLE
fix: project not required for canceling

### DIFF
--- a/src/commands/project/deploy/cancel.ts
+++ b/src/commands/project/deploy/cancel.ts
@@ -22,7 +22,6 @@ export default class DeployMetadataCancel extends SfCommand<DeployResultJson> {
   public static readonly description = messages.getMessage('description');
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
-  public static readonly requiresProject = true;
   public static readonly aliases = ['deploy:metadata:cancel'];
   public static readonly deprecateAliases = true;
 

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -201,11 +201,10 @@ export async function cancelDeploy(opts: Partial<DeployOptions>, id: string): Pr
   if (!deploy.id) {
     throw new SfError('The deploy id is not available.');
   }
-  const componentSet = await buildComponentSet({ ...opts });
   await DeployCache.set(deploy.id, { ...opts });
 
   await deploy.cancel();
-  return poll(org, deploy.id, opts.wait ?? Duration.minutes(33), componentSet);
+  return poll(org, deploy.id, opts.wait ?? Duration.minutes(33));
 }
 
 export async function cancelDeployAsync(opts: Partial<DeployOptions>, id: string): Promise<{ id: string }> {


### PR DESCRIPTION
### What does this PR do?
`project deploy cancel` command no longer requires a project.

### What issues does this PR fix or reference?
@W-13608500@
https://github.com/forcedotcom/cli/issues/2224