### PR TITLE
fix: deploy validate doesn\'t require a project

### DIFF
--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -24,7 +24,6 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
   public static readonly description = messages.getMessage('description');
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
-  public static readonly requiresProject = true;
   public static readonly aliases = ['deploy:metadata:quick'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -23,7 +23,6 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
   public static readonly description = messages.getMessage('description');
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
-  public static readonly requiresProject = true;
   public static readonly aliases = ['deploy:metadata:report'];
   public static readonly deprecateAliases = true;
 

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -31,7 +31,6 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
   public static readonly description = messages.getMessage('description');
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
-  public static readonly requiresProject = true;
   public static readonly aliases = ['deploy:metadata:validate'];
   public static readonly deprecateAliases = true;
 


### PR DESCRIPTION
### What does this PR do?

In certain scenarios, when using `--metadata-dir` the `project deploy validate` command doesn't require a project, but `requiresProject=true` so it would throw an error

remove that line so it can be executed outside of a project

### What issues does this PR fix or reference?
@W-13721102@
https://github.com/forcedotcom/cli/issues/2275

```bash
 ➜  ../oss/plugin-deploy-retrieve/bin/dev project deploy validate --metadata-dir temp --async --target-org test-iyv4subkohvd@example.com 
Validating Deployment of vundefined metadata to test-iyv4subkohvd@example.com using the v58.0 SOAP API.
Deploy ID: 0AfDH00001iUqjP0AS
Deploy has been queued.

Run "sf project deploy resume --job-id 0AfDH00001iUqjP0AS" to resume watching the deploy.
Run "sf project deploy report --job-id 0AfDH00001iUqjP0AS" to get the latest status.
Run "sf project deploy cancel --job-id 0AfDH00001iUqjP0AS" to cancel the deploy.

➜  scratches 
 ➜  sf project deploy validate --metadata-dir temp --async --target-org test-iyv4subkohvd@example.com 
    RequiresProjectError: This command is required to run from within a Salesforce project directory.
    Code: RequiresProjectError
```