### PR TITLE
fix: omit test warn if no reports are requested

### DIFF
--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -72,9 +72,12 @@ export class DeployResultFormatter extends TestResultsFormatter implements Forma
         testsWarn += `\`--junit\` was specified but no tests ran.${EOL}`;
       }
 
-      testsWarn +=
-        'You can ensure tests run by specifying `--test-level` and setting it to `RunSpecifiedTests`, `RunLocalTests` or `RunAllTestsInOrg`.';
-      await Lifecycle.getInstance().emitWarning(testsWarn);
+      // only emit warning if --coverage-formatters or --junit flags were passed
+      if (testsWarn.length > 0) {
+        testsWarn +=
+          'You can ensure tests run by specifying `--test-level` and setting it to `RunSpecifiedTests`, `RunLocalTests` or `RunAllTestsInOrg`.';
+        await Lifecycle.getInstance().emitWarning(testsWarn);
+      }
     }
 
     if (this.coverageOptions.reportFormats?.length) {


### PR DESCRIPTION
### What does this PR do?
Updates deploy formatter to only emit missing test warning if junit or codecov flags are passed.

![Screenshot 2023-07-31 at 09 22 39](https://github.com/salesforcecli/plugin-deploy-retrieve/assets/6853656/1c5e7f03-714b-4288-877a-9fa67850733a)

### What issues does this PR fix or reference?
[skip-validate-wi]