### PR TITLE
test: nuts that can run on v59

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^4.0.7",
-    "@salesforce/cli-plugins-testkit": "^4.2.9",
+    "@salesforce/cli-plugins-testkit": "^4.3.0",
     "@salesforce/dev-config": "^4.0.1",
     "@salesforce/dev-scripts": "^5.7.0",
     "@salesforce/plugin-command-reference": "^3.0.25",

--- a/test/nuts/delete/source.nut.ts
+++ b/test/nuts/delete/source.nut.ts
@@ -100,7 +100,9 @@ describe('project delete source NUTs', () => {
     const apexName = 'myApexClass';
     const output = path.join('force-app', 'main', 'default', 'classes');
     const pathToClass = path.join(testkit.projectDir, output, `${apexName}.cls`);
-    execCmd(`force:apex:class:create --classname ${apexName} --outputdir ${output}`, { ensureExitCode: 0 });
+    execCmd(`force:apex:class:create --classname ${apexName} --outputdir ${output} --api-version 58.0`, {
+      ensureExitCode: 0,
+    });
     execCmd(`force:source:deploy -m ApexClass:${apexName}`, { ensureExitCode: 0 });
     return { apexName, output, pathToClass };
   };

--- a/test/nuts/destructive/destructiveChanges.nut.ts
+++ b/test/nuts/destructive/destructiveChanges.nut.ts
@@ -31,7 +31,9 @@ describe('project deploy start --destructive NUTs', () => {
     // create and deploy an ApexClass that can be deleted without dependency issues
     const output = path.join('force-app', 'main', 'default', 'classes');
     const pathToClass = path.join(testkit.projectDir, output, `${apexName}.cls`);
-    execCmd(`force:apex:class:create --classname ${apexName} --outputdir ${output}`, { ensureExitCode: 0 });
+    execCmd(`force:apex:class:create --classname ${apexName} --outputdir ${output} --api-version 58.0`, {
+      ensureExitCode: 0,
+    });
     execCmd(`project:deploy:start -m ApexClass:${apexName}`, { ensureExitCode: 0 });
     return { apexName, output, pathToClass };
   };

--- a/test/nuts/tracking/forceIgnore.nut.ts
+++ b/test/nuts/tracking/forceIgnore.nut.ts
@@ -103,7 +103,7 @@ describe('forceignore changes', () => {
       await fs.promises.writeFile(path.join(session.project.dir, '.forceignore'), newForceIgnore);
 
       // add a file in the local source
-      shell.exec(`sfdx force:apex:class:create -n UnIgnoreTest --outputdir ${classdir}`, {
+      shell.exec(`sfdx force:apex:class:create -n UnIgnoreTest --outputdir ${classdir} --api-version 58.0`, {
         cwd: session.project.dir,
         silent: true,
       });

--- a/test/nuts/tracking/forceIgnore.nut.ts
+++ b/test/nuts/tracking/forceIgnore.nut.ts
@@ -41,7 +41,10 @@ describe('forceignore changes', () => {
       ],
     });
 
-    execCmd(`force:apex:class:create -n IgnoreTest --outputdir ${classdir}`, { cli: 'sfdx', ensureExitCode: 0 });
+    execCmd(`force:apex:class:create -n IgnoreTest --outputdir ${classdir} --api-version 58.0`, {
+      cli: 'sfdx',
+      ensureExitCode: 0,
+    });
     originalForceIgnore = await fs.promises.readFile(path.join(session.project.dir, '.forceignore'), 'utf8');
     conn = await Connection.create({
       authInfo: await AuthInfo.create({

--- a/test/nuts/tracking/forceIgnore.nut.ts
+++ b/test/nuts/tracking/forceIgnore.nut.ts
@@ -28,6 +28,7 @@ describe('forceignore changes', () => {
     session = await TestSession.create({
       project: {
         name: 'forceIgnoreTest',
+        apiVersion: '58.0',
       },
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,14 +979,14 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/cli-plugins-testkit@^4.2.6", "@salesforce/cli-plugins-testkit@^4.2.9":
-  version "4.2.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.2.9.tgz#813bbb6a7926d17d5d0becd664e08f1c115680d1"
-  integrity sha512-v71dFmhlgwtmehK2QJ8+toeCYc39WQFu7R2wmhsHQeVA1UuYcx3uue5JnC392PIXddxQtjdR6eazk52tQg4nyA==
+"@salesforce/cli-plugins-testkit@^4.2.6", "@salesforce/cli-plugins-testkit@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.3.0.tgz#253079d476569fbc4977c8100b3bf201b3e4a788"
+  integrity sha512-kW59i4muO49evQ76waWTfDUXpTfyBUQ0N1QIF4ZFB+aSAdVGG5N/oTMYz882ScS/SwB0XP0H119wT4cLoJI+Mw==
   dependencies:
     "@salesforce/core" "^5.2.0"
     "@salesforce/kit" "^3.0.9"
-    "@salesforce/ts-types" "^2.0.2"
+    "@salesforce/ts-types" "^2.0.6"
     "@types/shelljs" "^0.8.12"
     debug "^4.3.1"
     jszip "^3.10.1"


### PR DESCRIPTION
> requires https://github.com/salesforcecli/cli-plugins-testkit/pull/539

### What does this PR do?
templates goes to v59, but the org might not support it for a few weeks.

This sets the api version on the created classes and the testkit project sourceApiVersion

### What issues does this PR fix or reference?
[@W-13913391@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001XvsAqYAJ/view)
kinda caused by our rollout of [@W-13586057@](https://gus.lightning.force.com/a07EE00001Tl80JYAR)
example of the problem this solves: https://github.com/salesforcecli/cli/actions/runs/5804183268/job/15734000727