### PR TITLE
Update prompt help for generate topic

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
             "description": "Commands to delete metadata from a Salesforce org."
           },
           "generate": {
-            "description": "Commands to create a manifest file."
+            "description": "Commands to create file artifacts, such as a project or manifest file."
           },
           "reset": {
             "description": "Commands to reset the source tracking state."


### PR DESCRIPTION
### What does this PR do? 
Updates the text when user uses `--help` flag on `generate` topics. 

It was:
> Commands to create a manifest file.

To be updated to: 
> Commands to create file artifacts, such as a project or manifest file.

### What issues does this PR fix or reference?
Discussed with @mshanemc in public Slack workspaace.  [@W-14051727@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ZmCcBYAV/view)
