### PR TITLE
Sm/default-wait-on-report

### DIFF
--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -74,7 +74,6 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
     const jobId = cache.resolveLatest(flags['use-most-recent'], flags['job-id'], false);
 
     const deployOpts = cache.get(jobId) ?? {};
-    const waitDuration = flags['wait'];
     const org = flags['target-org'] ?? (await Org.create({ aliasOrUsername: deployOpts['target-org'] }));
 
     // if we're using mdapi we won't have a component set
@@ -85,12 +84,18 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
         try {
           this.project = await SfProject.resolve();
           const sourcepath = this.project.getUniquePackageDirectories().map((pDir) => pDir.fullPath);
-          componentSet = await buildComponentSet({ 'source-dir': sourcepath, wait: waitDuration });
+          componentSet = await buildComponentSet({
+            'source-dir': sourcepath,
+            wait: flags['wait'].quantity > 0 ? flags['wait'] : undefined,
+          });
         } catch (err) {
           // ignore the error. this was just to get improved command output.
         }
       } else {
-        componentSet = await buildComponentSet({ ...deployOpts, wait: waitDuration });
+        componentSet = await buildComponentSet({
+          ...deployOpts,
+          wait: flags['wait'].quantity > 0 ? flags['wait'] : undefined,
+        });
       }
     }
     const mdapiDeploy = new MetadataApiDeploy({
@@ -117,11 +122,11 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
     };
 
     let result: DeployResult;
-    if (waitDuration) {
+    if (flags.wait.quantity > 0) {
       // poll for deploy results
       try {
         new DeployProgress(mdapiDeploy, this.jsonEnabled()).start();
-        result = await mdapiDeploy.pollStatus(500, waitDuration.seconds);
+        result = await mdapiDeploy.pollStatus(500, flags.wait.seconds);
       } catch (error) {
         if (error instanceof Error && error.message.includes('The client has timed out')) {
           this.debug('[project deploy report] polling timed out. Requesting status...');

--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -8,6 +8,7 @@
 import { Messages, Org, SfProject } from '@salesforce/core';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { ComponentSet, DeployResult, MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
+import { Duration } from '@salesforce/kit';
 import { buildComponentSet } from '../../../utils/deploy';
 import { DeployProgress } from '../../../utils/progressBar';
 import { DeployCache } from '../../../utils/deployCache';
@@ -57,15 +58,14 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
       summary: messages.getMessage('flags.results-dir.summary'),
       helpGroup: testFlags,
     }),
-    // we want to allow undefined for a simple check deploy status
-    // eslint-disable-next-line sf-plugin/flag-min-max-default
     wait: Flags.duration({
       char: 'w',
       summary: deployMessages.getMessage('flags.wait.summary'),
       description: deployMessages.getMessage('flags.wait.description'),
       unit: 'minutes',
       helpValue: '<minutes>',
-      min: 1,
+      min: 0,
+      default: new Duration(0, Duration.Unit.MINUTES),
     }),
   };
 

--- a/src/commands/project/deploy/report.ts
+++ b/src/commands/project/deploy/report.ts
@@ -84,18 +84,12 @@ export default class DeployMetadataReport extends SfCommand<DeployResultJson> {
         try {
           this.project = await SfProject.resolve();
           const sourcepath = this.project.getUniquePackageDirectories().map((pDir) => pDir.fullPath);
-          componentSet = await buildComponentSet({
-            'source-dir': sourcepath,
-            wait: flags['wait'].quantity > 0 ? flags['wait'] : undefined,
-          });
+          componentSet = await buildComponentSet({ 'source-dir': sourcepath, wait: flags['wait'] });
         } catch (err) {
           // ignore the error. this was just to get improved command output.
         }
       } else {
-        componentSet = await buildComponentSet({
-          ...deployOpts,
-          wait: flags['wait'].quantity > 0 ? flags['wait'] : undefined,
-        });
+        componentSet = await buildComponentSet({ ...deployOpts, wait: flags['wait'] });
       }
     }
     const mdapiDeploy = new MetadataApiDeploy({


### PR DESCRIPTION
### What does this PR do?
makes 0 the default wait.
- This gets it set into the deployOptions as 0 when the user doesn't specify a wait
- also avoid the potential for `undefined minutes` in the table output