### PR TITLE
fix: add examples to project reset|delete tracking

### DIFF
--- a/messages/delete.tracking.md
+++ b/messages/delete.tracking.md
@@ -10,7 +10,23 @@ Resets local and remote source tracking so that Salesforce CLI no longer registe
 
 Use the --revision parameter to reset source tracking to a specific revision number of an org source member. To get the revision number, query the SourceMember Tooling API object with the 'data soql' command. For example:
 
-<%= config.bin %> data query --query "SELECT MemberName, MemberType, RevisionCounter FROM SourceMember" --use-tooling-api
+    <%= config.bin %> data query --query "SELECT MemberName, MemberType, RevisionCounter FROM SourceMember" --use-tooling-api --target-org my-scratch
+
+# resetExample
+
+- Reset source tracking for the org with alias "my-scratch":
+
+  $ <%= config.bin %> <%= command.id %> --target-org my-scratch
+
+- Reset source tracking to revision number 30 for your default org:
+
+  $ <%= config.bin %> <%= command.id %> --revision 30
+
+# deleteExample
+
+- Delete local source tracking for the org with alias "my-scratch":
+
+  $ <%= config.bin %> <%= command.id %> --target-org my-scratch
 
 # deleteSummary
 
@@ -32,8 +48,8 @@ SourceMember revision counter number to reset to.
 
 # promptMessage
 
-WARNING: This operation will modify all your local source tracking files. The operation can have unintended consequences on all the force:source commands. Are you sure you want to proceed?
+WARNING: This operation will modify all your local source tracking files. The operation can have unintended consequences on all the "project deploy" and "project retrieve" commands. Are you sure you want to proceed?
 
 # conflictMsg
 
-We couldn't complete the operation due to conflicts. Verify that you want to keep the existing versions, then run the command again with the --forceoverwrite (-f) option.
+We couldn't complete the operation due to conflicts. Verify that you want to keep the existing versions, then run the command again with the --forceoverwrite (-f) flag.

--- a/src/commands/project/delete/tracking.ts
+++ b/src/commands/project/delete/tracking.ts
@@ -29,7 +29,7 @@ export class DeleteTracking extends SfCommand<DeleteTrackingResult> {
   public static readonly summary = messages.getMessage('deleteSummary');
   public static readonly description = messages.getMessage('deleteDescription');
   public static readonly requiresProject = true;
-  public static readonly examples = [];
+  public static readonly examples = messages.getMessages('deleteExample');
 
   public static readonly flags = {
     'api-version': orgApiVersionFlagWithDeprecations,

--- a/src/commands/project/reset/tracking.ts
+++ b/src/commands/project/reset/tracking.ts
@@ -30,7 +30,7 @@ export class ResetTracking extends SfCommand<ResetTrackingResult> {
   public static readonly summary = messages.getMessage('resetSummary');
   public static readonly description = messages.getMessage('resetDescription');
   public static readonly requiresProject = true;
-  public static readonly examples = [];
+  public static readonly examples = messages.getMessages('resetExample');
 
   public static readonly flags = {
     'target-org': requiredOrgFlagWithDeprecations,


### PR DESCRIPTION
### What does this PR do?

Adds examples to project delete|reset tracking.  Previously "reset" had an example of querying SourceMember only, which was confusing.  Also fixed a lingering mention of "force:source". 

### What issues does this PR fix or reference?

@W-14191974@
