### PR TITLE
fix: api version for mdapi deploys

### DIFF
--- a/messages/deploy.metadata.md
+++ b/messages/deploy.metadata.md
@@ -78,7 +78,7 @@ Overrides your default org.
 
 # flags.metadata.summary
 
-Metadata component names to deploy. Wildcards ( * ) supported as long as you use quotes, such as 'ApexClass:MyClass*'
+Metadata component names to deploy. Wildcards ( `*` ) supported as long as you use quotes, such as `ApexClass:MyClass*`
 
 # flags.test-level.summary
 
@@ -246,4 +246,4 @@ The `pushPackageDirectoriesSequentially` property is not respected by this comma
 
 # apiVersionMsgDetailed
 
-%s v%s metadata to %s using the v%s %s API.
+%s %s metadata to %s using the v%s %s API.

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -207,7 +207,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       this.log(
         messages.getMessage('apiVersionMsgDetailed', [
           action,
-          apiData.manifestVersion,
+          flags['metadata-dir'] ? '<version specified in manifest>' : `v${apiData.manifestVersion}`,
           username,
           apiData.apiVersion,
           apiData.webService,

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -168,7 +168,7 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
       this.log(
         deployMessages.getMessage('apiVersionMsgDetailed', [
           'Validating Deployment of',
-          apiData.manifestVersion,
+          flags['metadata-dir'] ? '<version specified in manifest>' : `v${apiData.manifestVersion}`,
           username,
           apiData.apiVersion,
           apiData.webService,

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -192,7 +192,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
         this.log(
           messages.getMessage('apiVersionMsgDetailed', [
             'Retrieving',
-            apiData.manifestVersion,
+            `v${apiData.manifestVersion}`,
             flags['target-org'].getUsername(),
             apiData.apiVersion,
           ])


### PR DESCRIPTION
### What does this PR do?
1. use `--api-version` flag on mdapi deploys
2. api message indicates that manifest controls the sourceApiVersion for mdapi deploys

### What issues does this PR fix or reference?
[@W-14209534@](https://gus.lightning.force.com/a07EE00001bTEuoYAG)