### PR TITLE
feat: col, line numbers on mdapi deploy errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@salesforce/core": "^5.2.7",
     "@salesforce/kit": "^3.0.9",
     "@salesforce/sf-plugins-core": "^3.1.22",
-    "@salesforce/source-deploy-retrieve": "^9.7.15",
+    "@salesforce/source-deploy-retrieve": "^9.7.24",
     "@salesforce/source-tracking": "^4.2.16",
     "chalk": "^4.1.2",
     "shelljs": "^0.8.5",

--- a/test/utils/output.test.ts
+++ b/test/utils/output.test.ts
@@ -34,11 +34,7 @@ describe('deployResultFormatter', () => {
         {
           error: 'This component has some problems',
           fullName: 'ProductController',
-          problemType: 'Error',
-        },
-        {
-          error: 'This component has some problems',
-          fullName: 'ProductController',
+          loc: '27:18',
           problemType: 'Error',
         },
       ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,16 +1121,16 @@
     chalk "^4"
     inquirer "^8.2.5"
 
-"@salesforce/source-deploy-retrieve@^9.7.15", "@salesforce/source-deploy-retrieve@^9.7.2", "@salesforce/source-deploy-retrieve@^9.7.20":
-  version "9.7.21"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.7.21.tgz#9d1b65ce0d50080a6886d04779049127ee7f37b9"
-  integrity sha512-MJvaDLzPUVpizdNGQ4ufwkmX8ogcQ0E1WkoTaPE0yionJgmIR78035TtJgnkuj+SDhHWhX1ABKbrkxzLn7obMg==
+"@salesforce/source-deploy-retrieve@^9.7.2", "@salesforce/source-deploy-retrieve@^9.7.20", "@salesforce/source-deploy-retrieve@^9.7.24":
+  version "9.7.24"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.7.24.tgz#6a200b830311b0db08a86026ece98c734d56f8c2"
+  integrity sha512-nkP9KgzuCoV6LtdDxgxt7KRnoQ6ZS12DJgXErCBXm7Swmr0dnbo1LhxrH05C4UFFe0JuvSta+u+Oor8jxSGaCQ==
   dependencies:
     "@salesforce/core" "^5.3.1"
     "@salesforce/kit" "^3.0.11"
     "@salesforce/ts-types" "^2.0.7"
     fast-levenshtein "^3.0.0"
-    fast-xml-parser "^4.2.7"
+    fast-xml-parser "^4.3.2"
     got "^11.8.6"
     graceful-fs "^4.2.11"
     ignore "^5.2.4"
@@ -3590,10 +3590,10 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-xml-parser@^4.2.5, fast-xml-parser@^4.2.7:
-  version "4.2.7"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz#871f2ca299dc4334b29f8da3658c164e68395167"
-  integrity sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==
+fast-xml-parser@^4.2.5, fast-xml-parser@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz#761e641260706d6e13251c4ef8e3f5694d4b0d79"
+  integrity sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
> requires https://github.com/forcedotcom/source-deploy-retrieve/pull/1130

### What does this PR do?
- show col/line numbers on component fails
- sort the failures table better
- remove duplicate failure reporting

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/356
@W-14247072@