### PR TITLE
Cb/set default testlevel flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Add a new deploy command
 
-The deploy-retrieve plugin does not have any commands for deploying or or retrieving specific pieces of a salesforce project (e.g. metadata to a scratch or functions to a compute environment). Instead, we ask developers to create their own plugin with those commands. In order for the `deploy` or `retrieve` commands to know about the individual plugins, each plugin must implement an [oclif hook](https://oclif.io/docs/hooks) which returns [`Deployers`](https://github.com/salesforcecli/plugin-deploy-retrieve-utils/blob/main/src/deployer.ts) and `Retirevers`.
+The deploy-retrieve plugin does not have any commands for deploying or or retrieving specific pieces of a salesforce project (e.g. metadata to a scratch or functions to a compute environment). Instead, we ask developers to create their own plugin with those commands. In order for the `deploy` or `retrieve` commands to know about the individual plugins, each plugin must implement an [oclif hook](https://oclif.io/docs/hooks) which returns [`Deployers`](https://github.com/salesforcecli/plugin-deploy-retrieve-utils/blob/main/src/deployer.ts) and `Retrievers`.
 
 This method allows developers to own their own plugins while also allowing a simple way for the overarching `project` topic to interact with those plugins.
 

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -71,6 +71,10 @@ export const ensuredDirFlag = Flags.custom<string>({
 export const testLevelFlag = Flags.custom<TestLevel>({
   char: 'l',
   parse: (input) => Promise.resolve(input as TestLevel),
+  // eslint-disable-next-line @typescript-eslint/require-await
+  default: async (context) => {
+    if (context.flags.tests) return TestLevel.RunSpecifiedTests;
+  },
   options: Object.values(TestLevel),
 });
 
@@ -91,7 +95,6 @@ export const zipFileFlag = Flags.custom<string>({
 export const testsFlag = Flags.string({
   char: 't',
   multiple: true,
-  dependsOn: ['test-level'],
   summary: commonFlagMessages.getMessage('flags.tests.summary'),
   description: commonFlagMessages.getMessage('flags.tests.description'),
   // the old version allowed comma separated values, and the change is confusing enough to deserve a warning

--- a/test/nuts/seeds/deploy.metadata.test-level.seed.ts
+++ b/test/nuts/seeds/deploy.metadata.test-level.seed.ts
@@ -69,6 +69,15 @@ context('deploy metadata --test-level NUTs [name: %REPO_NAME%]', () => {
       });
       await testkit.expect.specificApexTestsToBeRun(REPO.deploy.testLevel.specifiedTests);
     });
+
+    it('should set --test-level flag to (RunSpecifiedTests) if --tests flag is included', async () => {
+      const packages = testkit.packageNames.map((p) => `--source-dir ${p}`).join(' ');
+      const tests = REPO.deploy.testLevel.specifiedTests.join(',');
+      await testkit.deploy({
+        args: `${packages} --tests ${tests}`,
+      });
+      await testkit.expect.specificApexTestsToBeRun(REPO.deploy.testLevel.specifiedTests);
+    });
   });
 
   describe('test result format', () => {


### PR DESCRIPTION
### What does this PR do?

Defaults `--test-level` flag to `RunSpecifiedTests` if `--tests` flag is present

- Avoids redundant user input

Fixes minor typo in `CONTRIBUTING.md` file

### What issues does this PR fix or reference?
Issue #2396: https://github.com/forcedotcom/cli/issues/2396
