### PR TITLE
fix: quick deploy polling uses the new deploy ID

### DIFF
--- a/test/commands/deploy/metadata/quick.nut.ts
+++ b/test/commands/deploy/metadata/quick.nut.ts
@@ -82,7 +82,7 @@ describe('deploy metadata quick NUTs', () => {
   });
 
   describe('--job-id', () => {
-    it('should deploy previously validated deployment', async () => {
+    it('should deploy previously validated deployment (async)', async () => {
       const validation = await testkit.execute<DeployResultJson>('project:deploy:validate', {
         args: '--source-dir force-app',
         json: true,
@@ -97,6 +97,26 @@ describe('deploy metadata quick NUTs', () => {
         exitCode: 0,
       });
       assert(deploy);
+      assert(deploy.result.id !== validation.result.id, 'deploy result ID should not be the validation ID');
+      await testkit.expect.filesToBeDeployed(['force-app/**/*'], ['force-app/test/**/*']);
+    });
+
+    it('should deploy previously validated deployment (poll)', async () => {
+      const validation = await testkit.execute<DeployResultJson>('project:deploy:validate', {
+        args: '--source-dir force-app',
+        json: true,
+        exitCode: 0,
+      });
+      assert(validation);
+      await testkit.expect.filesToBeDeployed(['force-app/**/*'], ['force-app/test/**/*']);
+
+      const deploy = await testkit.execute<DeployResultJson>('project:deploy:quick', {
+        args: `--job-id ${validation.result.id} --wait 20`,
+        json: true,
+        exitCode: 0,
+      });
+      assert(deploy);
+      assert(deploy.result.id !== validation.result.id, 'deploy result ID should not be the validation ID');
       await testkit.expect.filesToBeDeployed(['force-app/**/*'], ['force-app/test/**/*']);
     });
 


### PR DESCRIPTION
### What does this PR do?
Changes quick deploy to use the new deploy ID and not the validation ID.  Augments NUTs to ensure this behavior.

### What issues does this PR fix or reference?
@W-14481091@
https://github.com/forcedotcom/cli/issues/2537