### PR TITLE
test: assert nonZero exit codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.0.3",
-    "@salesforce/cli-plugins-testkit": "^5.0.4",
+    "@salesforce/cli-plugins-testkit": "^5.1.0",
     "@salesforce/dev-scripts": "^8.0.0",
     "@salesforce/plugin-command-reference": "^3.0.48",
     "@salesforce/plugin-source": "^2.11.4",

--- a/test/nuts/convert/mdapi.nut.ts
+++ b/test/nuts/convert/mdapi.nut.ts
@@ -49,10 +49,10 @@ describe('project convert mdapi NUTs', () => {
     });
     describe('failures', () => {
       it('should error when outputdir is not a directory', () => {
-        execCmd('project:convert:mdapi --output-dir package.json', { ensureExitCode: 1 });
+        execCmd('project:convert:mdapi --output-dir package.json', { ensureExitCode: 'nonZero' });
       });
       it('should error when metadatapath does not exist', () => {
-        execCmd('project:convert:mdapi --metadata-dir not/a/real/path -d mdapiOut', { ensureExitCode: 1 });
+        execCmd('project:convert:mdapi --metadata-dir not/a/real/path -d mdapiOut', { ensureExitCode: 'nonZero' });
       });
       it('should throw when no metadata to convert converted (json)', async () => {
         const emptyManifest = 'emptyManifest.xml';

--- a/test/nuts/convert/source.nut.ts
+++ b/test/nuts/convert/source.nut.ts
@@ -42,10 +42,10 @@ describe('project convert source NUTs', () => {
   describe('source:convert', () => {
     describe('failures', () => {
       it('should error when outputdir is not a directory', () => {
-        execCmd('project:convert:source --output-dir package.json', { ensureExitCode: 1 });
+        execCmd('project:convert:source --output-dir package.json', { ensureExitCode: 'nonZero' });
       });
       it('should error when metadatapath does not exist', () => {
-        execCmd('project:convert:source --metadata-dir not/a/real/path -d mdapiOut', { ensureExitCode: 1 });
+        execCmd('project:convert:source --metadata-dir not/a/real/path -d mdapiOut', { ensureExitCode: 'nonZero' });
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,6 +989,21 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.1"
 
+"@salesforce/cli-plugins-testkit@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.1.0.tgz#8d9caa22ea9e99879629206892afb26bcd540cef"
+  integrity sha512-P5tYlNqE87lX9Yp2aAsK75PICoAbmrSK3LEqiIVbtn75PN3OKiD1JEEX2ZDu+HWtO4/nxPtO4JFvX5j00EZGBA==
+  dependencies:
+    "@salesforce/core" "^6.2.2"
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/ts-types" "^2.0.9"
+    "@types/shelljs" "^0.8.15"
+    debug "^4.3.1"
+    jszip "^3.10.1"
+    shelljs "^0.8.4"
+    strip-ansi "6.0.1"
+    ts-retry-promise "^0.7.1"
+
 "@salesforce/core@^5.3.17", "@salesforce/core@^5.3.18", "@salesforce/core@^5.3.20":
   version "5.3.20"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.20.tgz#4e934d4551bb70423cb1c4115615bc41cffca41e"


### PR DESCRIPTION
### What does this PR do?

Assert that failed exit codes are `nonZero` instead of `1`. Should fix `just-nuts` in nightly release

### What issues does this PR fix or reference?
[skip-validate-pr]