### PR TITLE
fix: don't cast opts to boolean

### DIFF
--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
-
 import { ConfigAggregator, Messages, Org, SfError, SfProject } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { Nullable } from '@salesforce/ts-types';
@@ -26,7 +24,7 @@ import { DEPLOY_STATUS_CODES } from './errorCodes.js';
 import { DeployCache } from './deployCache.js';
 import { writeManifest } from './manifestCache.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 export const cacheMessages = Messages.loadMessages('@salesforce/plugin-deploy-retrieve', 'cache');
 
 const deployMessages = Messages.loadMessages('@salesforce/plugin-deploy-retrieve', 'deploy.metadata');
@@ -156,7 +154,7 @@ export async function executeDeploy(
     });
     componentSet = await buildComponentSet(opts, stl);
     if (componentSet.size === 0) {
-      if (Boolean(opts['source-dir']) ?? Boolean(opts.manifest) ?? Boolean(opts.metadata) ?? throwOnEmpty) {
+      if (opts['source-dir'] ?? opts.manifest ?? opts.metadata ?? throwOnEmpty) {
         // the user specified something to deploy, but there isn't anything
         throw new SfError(
           deployMessages.getMessage('error.nothingToDeploy'),

--- a/test/nuts/deploy/metadata.nut.ts
+++ b/test/nuts/deploy/metadata.nut.ts
@@ -10,7 +10,6 @@ import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { expect } from 'chai';
 import { SourceTestkit } from '@salesforce/source-testkit';
-import { SfError } from '@salesforce/core';
 import { DeployResultJson } from '../../../src/utils/types.js';
 
 const packageXml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -39,10 +38,12 @@ describe('deploy metadata NUTs', () => {
   });
 
   it('should throw if component set is empty', async () => {
-    const response = await testkit.deploy({ args: '--manifest package.xml --dry-run' });
-    expect(response?.status).to.equal(1);
-    const result = response?.result as unknown as SfError;
-    expect(result.name).to.equal('NothingToDeploy');
+    try {
+      await testkit.deploy({ args: '--manifest package.xml --dry-run', json: true, exitCode: 1 });
+    } catch (e) {
+      const err = e as Error;
+      expect(err.name).to.equal('NothingToDeploy');
+    }
   });
 
   it('should deploy ApexClasses from wildcard match (single character)', async () => {

--- a/test/nuts/deploy/metadata.nut.ts
+++ b/test/nuts/deploy/metadata.nut.ts
@@ -39,7 +39,7 @@ describe('deploy metadata NUTs', () => {
   });
 
   it('should throw if component set is empty', async () => {
-    const response = await testkit.deploy({ args: '' });
+    const response = await testkit.deploy({ args: '--manifest package.xml --dry-run' });
     expect(response?.status).to.equal(1);
     const result = response?.result as unknown as SfError;
     expect(result.name).to.equal('NothingToDeploy');

--- a/test/nuts/deploy/metadata.nut.ts
+++ b/test/nuts/deploy/metadata.nut.ts
@@ -5,13 +5,24 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { join } from 'node:path';
+import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { expect } from 'chai';
 import { SourceTestkit } from '@salesforce/source-testkit';
+import { SfError } from '@salesforce/core';
 import { DeployResultJson } from '../../../src/utils/types.js';
+
+const packageXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <version>59.0</version>
+</Package>
+`;
 
 describe('deploy metadata NUTs', () => {
   let testkit: SourceTestkit;
+  const packageFile = 'package.xml';
+  let xmlPath: string | undefined;
 
   before(async () => {
     testkit = await SourceTestkit.create({
@@ -19,10 +30,19 @@ describe('deploy metadata NUTs', () => {
       nut: fileURLToPath(import.meta.url),
     });
     await testkit.deploy({ args: '--source-dir force-app', exitCode: 0 });
+    xmlPath = join(testkit.projectDir, packageFile);
+    await fs.promises.writeFile(xmlPath, packageXml);
   });
 
   after(async () => {
     await testkit?.clean();
+  });
+
+  it('should throw if component set is empty', async () => {
+    const response = await testkit.deploy({ args: '' });
+    expect(response?.status).to.equal(1);
+    const result = response?.result as unknown as SfError;
+    expect(result.name).to.equal('NothingToDeploy');
   });
 
   it('should deploy ApexClasses from wildcard match (single character)', async () => {


### PR DESCRIPTION
### What does this PR do?
Update empty component set check to not cast deploy opts from `boolean | undefined` to `boolean` when using the `??` operator. 

It was changed to casting + `??` operator here:
https://github.com/salesforcecli/plugin-deploy-retrieve/pull/799/commits/ad2cb256e720565c5ad963068110c902605121a8#diff-38ace718cac3391d646985bcdd7fd17d4114a116432f5c6846db797b46552080R157

So if you don't pass these flags these are `undefined` at runtime, then casted to boolean so the `??` op will always return `false` unless the flag was specified.

Repro:
1) clone dreamhouse & create scratch org
2) create `package.xml` with this content:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <version>59.0</version>
</Package>

```
3) try deploy using latest (below I'm using latest-rc with no linked plugins):
```
➜  dreamhouse-lwc git:(main) ✗ sf -v
@salesforce/cli/2.22.7 darwin-x64 node-v20.10.0
➜  dreamhouse-lwc git:(main) ✗ sf project deploy start --manifest package.xml --dry-run
No changes to deploy
➜  dreamhouse-lwc git:(main) ✗ echo $?
0
```

4) now link this branch of PDR and repeat step 3, should see:
```
➜  dreamhouse-lwc git:(main) ✗ sf project deploy start --manifest package.xml --dry-run
 ›   Warning: @salesforce/plugin-deploy-retrieve is a linked ESM module and cannot be auto-transpiled. Existing compiled source will be used instead.
Error (1): No local changes to deploy.

Try this:

To see conflicts and ignored files, run "sf project deploy preview" with any of the manifest, directory, or metadata flags.
➜  dreamhouse-lwc git:(main) ✗ echo $?
1
```

This regression was introduced in PDR v1.20.0, `@salesforce/cli@2.17.14`.

### What issues does this PR fix or reference?
Fixes: https://github.com/forcedotcom/cli/issues/2621
@W-14739817@