### PR TITLE
feat: add concise flag to deploy preview

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -79,7 +79,7 @@
     "command": "project:deploy:preview",
     "flagAliases": [],
     "flagChars": ["c", "d", "m", "o", "x"],
-    "flags": ["ignore-conflicts", "json", "manifest", "metadata", "source-dir", "target-org"],
+    "flags": ["ignore-conflicts", "json", "manifest", "metadata", "source-dir", "target-org", "concise"],
     "plugin": "@salesforce/plugin-deploy-retrieve"
   },
   {

--- a/messages/deploy.metadata.preview.md
+++ b/messages/deploy.metadata.preview.md
@@ -76,7 +76,7 @@ This flag applies only to orgs that allow source tracking. It has no effect on o
 
 # flags.concise.summary
 
-Omit ignored files.
+Show only the changes that will be deployed; omits files that are forceignored.
 
 # flags.api-version.summary
 

--- a/src/commands/project/deploy/preview.ts
+++ b/src/commands/project/deploy/preview.ts
@@ -58,6 +58,10 @@ export default class DeployMetadataPreview extends SfCommand<PreviewResult> {
       summary: messages.getMessage('flags.target-org.summary'),
       required: true,
     }),
+    concise: Flags.boolean({
+      summary: messages.getMessage('flags.concise.summary'),
+      default: false,
+    }),
   };
 
   public async run(): Promise<PreviewResult> {
@@ -88,7 +92,7 @@ export default class DeployMetadataPreview extends SfCommand<PreviewResult> {
     });
 
     if (!this.jsonEnabled()) {
-      printTables(output, 'deploy');
+      printTables(output, 'deploy', flags.concise);
     }
     return output;
   }

--- a/test/nuts/tracking/forceIgnore.nut.ts
+++ b/test/nuts/tracking/forceIgnore.nut.ts
@@ -193,13 +193,26 @@ describe('forceignore changes', () => {
       expect(pullOutput?.files.length).to.equal(0);
     });
 
-    it('will not display ignored files with --concise', () => {
+    it('will not display retrieved ignored files with --concise', () => {
       // gets file into source tracking
       const output = execCmd<PreviewResult>('project:retrieve:preview --concise', {
         ensureExitCode: 0,
       }).shellOutput.stdout;
       expect(output).to.not.include("These files won't retrieve because they're ignored by your .forceignore file.");
       expect(output).to.not.include('ApexClass CreatedClass');
+    });
+
+    it('will not display deployed ignored files with --concise', async () => {
+      const newForceIgnore = originalForceIgnore + '\n' + `${classdir}/IgnoreTest.cls*`;
+      await fs.promises.writeFile(path.join(session.project.dir, '.forceignore'), newForceIgnore);
+
+      const output = execCmd<DeployResultJson>(`project:deploy:preview -d ${classdir} --concise`, {
+        ensureExitCode: 0,
+      }).shellOutput.stdout;
+      expect(output).to.include('Will Deploy [1] files.');
+      expect(output).to.include('ApexClass UnIgnoreTest');
+      expect(output).to.not.include("These files won't deploy because they're ignored by your .forceignore file.");
+      expect(output).to.not.include('ApexClass IgnoreTest');
     });
   });
 });


### PR DESCRIPTION
NOTE: same as #873 but updates the test to be correct.

What does this PR do?
Adds flag --concise to project deploy preview to skip displaying ignored files.

I saw this implementation and thought it was an oversight to only include it as part of the retrieve command and not deploy. https://github.com/salesforcecli/plugin-deploy-retrieve/pull/831

I also noticed the flag doesn't have a description, although I'm not sure if one is needed.

@W-14818332@
