### PR TITLE
fix: bump SDR and STL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "@salesforce/core": "^6.4.4",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/sf-plugins-core": "^7.1.3",
-    "@salesforce/source-deploy-retrieve": "^10.2.11",
-    "@salesforce/source-tracking": "^5.1.5",
+    "@salesforce/source-deploy-retrieve": "^10.2.12",
+    "@salesforce/source-tracking": "^5.1.7",
     "@salesforce/ts-types": "^2.0.9",
     "chalk": "^5.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,10 +1787,10 @@
     "@salesforce/ts-types" "^2.0.9"
     chalk "^5.3.0"
 
-"@salesforce/source-deploy-retrieve@^10.0.0", "@salesforce/source-deploy-retrieve@^10.2.10", "@salesforce/source-deploy-retrieve@^10.2.11":
-  version "10.2.11"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.2.11.tgz#b3eaa75a1342d9dfbc8d84ff05d1a8ebf48b5241"
-  integrity sha512-XUoSn4I4Ki9m6rX/DaGpfM4PBu2TP/WSDszhlwvfktSO4XjLCqdI2B5KrGk/BQZ5KoxDQIhDp2G7rwgoyypJxw==
+"@salesforce/source-deploy-retrieve@^10.0.0", "@salesforce/source-deploy-retrieve@^10.2.10", "@salesforce/source-deploy-retrieve@^10.2.11", "@salesforce/source-deploy-retrieve@^10.2.12":
+  version "10.2.12"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.2.12.tgz#8311593f3be004530896d9264466b59ec64b0a76"
+  integrity sha512-i12707TLzzJTdt7/lXLFatOwSKW1VK/ns13A8/6/6QHElT6nEvnoxP/bah3BAl9x/mKh7Sr8hD6+3ObnYqha4A==
   dependencies:
     "@salesforce/core" "^6.4.7"
     "@salesforce/kit" "^3.0.15"
@@ -1822,7 +1822,7 @@
     shelljs "^0.8.4"
     sinon "^10.0.0"
 
-"@salesforce/source-tracking@^5.0.0", "@salesforce/source-tracking@^5.1.5":
+"@salesforce/source-tracking@^5.0.0":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@salesforce/source-tracking/-/source-tracking-5.1.5.tgz#a8ff65d738ed12ce585540d3efe4a8a4a65afafc"
   integrity sha512-4uQGz6Vg213CLDCGVI8VIxsFVguShEMDV535YHV3YPK/Q3ls4z4eOBk8vOrFpItlHuKpfYYmAKKy16AFJMgk2w==
@@ -1836,6 +1836,21 @@
     graceful-fs "^4.2.11"
     isomorphic-git "1.23.0"
     ts-retry-promise "^0.7.0"
+
+"@salesforce/source-tracking@^5.1.7":
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-tracking/-/source-tracking-5.1.7.tgz#2bfc3e6c9bf0aabd7ba5644a69977dfd1fef84c3"
+  integrity sha512-kkXWt4X+wxmYsLqG1OIWKgo3aFEg1f+1X6MBIHIrmjEmfMXIRiGX0dRyY+IjFl54w+CnOffNDQNsGSmnPImEYg==
+  dependencies:
+    "@oclif/core" "^3.18.1"
+    "@salesforce/core" "^6.4.7"
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/source-deploy-retrieve" "^10.2.12"
+    "@salesforce/ts-types" "^2.0.9"
+    fast-xml-parser "^4.2.5"
+    graceful-fs "^4.2.11"
+    isomorphic-git "1.23.0"
+    ts-retry-promise "^0.8.0"
 
 "@salesforce/ts-sinon@^1.4.19":
   version "1.4.19"


### PR DESCRIPTION
Bump to latest versions of SDR and STL to get a fix for the IdentityVerificationProcDev metadata type.

[skip-validate-pr]
