### PR TITLE
fix: allow purge-on-delete with mdapi dirs

### DIFF
--- a/messages/deploy.metadata.md
+++ b/messages/deploy.metadata.md
@@ -64,11 +64,11 @@ To deploy multiple metadata components, either set multiple --metadata <name> fl
 
       <%= config.bin %> <%= command.id %> --metadata ApexClass --test-level RunLocalTests
 
-- Deploy all "metadata formatted" metadata in the "MDAPI" directory:
+- Deploy all metadata formatted files in the "MDAPI" directory:
 
       <%= config.bin %> <%= command.id %> --metadata-dir MDAPI
 
-- Deploy all "metadata formatted" metadata in the "MDAPI" directory while hard deleting any items listed in MDAPI/destructiveChangesPre.xml or MDAPI/destructiveChangesPost.xml manifests:
+- Deploy all metadata formatted files in the "MDAPI" directory; items listed in the MDAPI/destructiveChangesPre.xml and MDAPI/destructiveChangesPost.xml manifests are immediately eligible for deletion rather than stored in the Recycle Bin:
 
       <%= config.bin %> <%= command.id %> --metadata-dir MDAPI --purge-on-delete
 

--- a/messages/deploy.metadata.md
+++ b/messages/deploy.metadata.md
@@ -64,6 +64,14 @@ To deploy multiple metadata components, either set multiple --metadata <name> fl
 
       <%= config.bin %> <%= command.id %> --metadata ApexClass --test-level RunLocalTests
 
+- Deploy all "metadata formatted" metadata in the "MDAPI" directory:
+
+      <%= config.bin %> <%= command.id %> --metadata-dir MDAPI
+
+- Deploy all "metadata formatted" metadata in the "MDAPI" directory while hard deleting any items listed in MDAPI/destructiveChangesPre.xml or MDAPI/destructiveChangesPost.xml manifests:
+
+      <%= config.bin %> <%= command.id %> --metadata-dir MDAPI --purge-on-delete
+
 # flags.pre-destructive-changes.summary
 
 File path for a manifest (destructiveChangesPre.xml) of components to delete before the deploy.

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -134,8 +134,9 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
     }),
     'purge-on-delete': Flags.boolean({
       summary: messages.getMessage('flags.purge-on-delete.summary'),
-      dependsOn: ['manifest'],
-      relationships: [{ type: 'some', flags: ['pre-destructive-changes', 'post-destructive-changes'] }],
+      relationships: [
+        { type: 'some', flags: ['pre-destructive-changes', 'manifest', 'metadata-dir', 'post-destructive-changes'] },
+      ],
       helpGroup: destructiveFlags,
     }),
     'pre-destructive-changes': Flags.file({

--- a/test/nuts/destructive/destructiveChanges.nut.ts
+++ b/test/nuts/destructive/destructiveChanges.nut.ts
@@ -6,7 +6,7 @@
  */
 
 import * as path from 'node:path';
-import fs, { writeFileSync } from 'node:fs';
+import { copyFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import { assert, expect } from 'chai';
@@ -246,11 +246,11 @@ describe('project deploy start --destructive NUTs', () => {
       createManifest(`ApexClass:${post}`, 'post');
       createManifest(`ApexClass:${pre}`, 'pre');
       // move the destructive changes files into the mdapi dirt
-      fs.copyFileSync(
+      copyFileSync(
         join(testkit.projectDir, 'destructiveChangesPre.xml'),
         join(testkit.projectDir, 'mdapi', 'destructiveChangesPre.xml')
       );
-      fs.copyFileSync(
+      copyFileSync(
         join(testkit.projectDir, 'destructiveChangesPost.xml'),
         join(testkit.projectDir, 'mdapi', 'destructiveChangesPost.xml')
       );


### PR DESCRIPTION
### What does this PR do?
allows a user to specify `--purge-on-delete --metadata-dir...` 
as long as the specified metadata-dir has a destructive manifest in it, it will be deleted, and reported, and removed from recycling

### What issues does this PR fix or reference?
@W-16010166@