### PR TITLE
fix: use full output-path on `convert mdapi`

### DIFF
--- a/src/commands/project/convert/mdapi.ts
+++ b/src/commands/project/convert/mdapi.ts
@@ -202,8 +202,13 @@ const ensureFlagPath = async (options: EnsureFsFlagOptions): Promise<string> => 
         throw new SfError(messages.getMessage('InvalidFlagPath', [flagName, path, enoent]), 'InvalidFlagPath');
       }
       const dir = type === 'dir' ? resolvedPath : dirname(resolvedPath);
-      // using as because fs promises always returns a string when recursive is true
-      return fs.promises.mkdir(dir, { recursive: true }) as Promise<string>;
+
+      await fs.promises.mkdir(dir, { recursive: true }).catch((err) => {
+        throw SfError.wrap(err);
+      });
+
+      // `fs.mkdir` will return only the first dir in the path so we return the full path here
+      return dir;
     }
   }
 };

--- a/test/nuts/convert/mdapi.nut.ts
+++ b/test/nuts/convert/mdapi.nut.ts
@@ -90,6 +90,10 @@ describe('project convert mdapi NUTs', () => {
       expect(result.jsonOutput?.status).to.equal(0);
       expect(result.jsonOutput?.result).to.be.an('array').with.length.greaterThan(10);
       expect(fs.existsSync(convertedToSrcPath)).to.be.true;
+      expect(result.jsonOutput).to.not.be.undefined;
+      result.jsonOutput?.result.forEach((md) => {
+        expect(md.filePath.startsWith(convertedToSrcPath)).to.be.true;
+      });
     });
 
     it('should convert the dreamhouse project using metadatapath flag', () => {

--- a/test/nuts/convert/mdapi.nut.ts
+++ b/test/nuts/convert/mdapi.nut.ts
@@ -82,7 +82,7 @@ describe('project convert mdapi NUTs', () => {
       expect(fs.existsSync(convertedToSrcPath)).to.be.true;
     });
 
-    it('should convert the dreamhouse project using metadata flag', () => {
+    it('should convert the dreamhouse project using metadata flag', async () => {
       const convertedToSrcPath = path.join(session.dir, 'convertedToSrcPath_metadataFlag');
       const result = execCmd<ConvertMdapiJson>(
         `project:convert:mdapi -r ${convertedToMdPath} -d ${convertedToSrcPath} -m ApexClass --json`
@@ -90,10 +90,9 @@ describe('project convert mdapi NUTs', () => {
       expect(result.jsonOutput?.status).to.equal(0);
       expect(result.jsonOutput?.result).to.be.an('array').with.length.greaterThan(10);
       expect(fs.existsSync(convertedToSrcPath)).to.be.true;
-      expect(result.jsonOutput).to.not.be.undefined;
-      result.jsonOutput?.result.forEach((md) => {
-        expect(md.filePath.startsWith(convertedToSrcPath)).to.be.true;
-      });
+
+      const files = await fs.promises.readdir(path.join(convertedToSrcPath, 'main', 'default', 'classes'));
+      expect(files.length).to.equal(result.jsonOutput?.result.length);
     });
 
     it('should convert the dreamhouse project using metadatapath flag', () => {


### PR DESCRIPTION
### What does this PR do?
Fix a bug where `project convert mdapi --output-dir path/to/output` would save the converted metadata to `path` instead of `path/to/output` if the path didn't exist before.

 When the dir doesn't exist we create it for the user but the code was returning `fs.promises.mkdir` response which only returned the first dir in the path:
https://nodejs.org/api/fs.html#fspromisesmkdirpath-options

Updated convert NUT to check that the filepath starts with the full output path.

### What issues does this PR fix or reference?
@W-15097291@