### PR TITLE
fix: prevent NaN in stage output

### DIFF
--- a/src/utils/deployStages.ts
+++ b/src/utils/deployStages.ts
@@ -32,6 +32,10 @@ function round(value: number, precision: number): number {
 }
 
 function formatProgress(current: number, total: number): string {
+  if (total === 0) {
+    return '0/0 (0%)';
+  }
+
   return `${current}/${total} (${round((current / total) * 100, 0)}%)`;
 }
 
@@ -99,11 +103,12 @@ export class DeployStages {
         {
           label: 'Members',
           get: (data): string | undefined =>
-            data?.sourceMemberPolling &&
-            formatProgress(
-              data.sourceMemberPolling.original - data.sourceMemberPolling.remaining,
-              data.sourceMemberPolling.original
-            ),
+            data?.sourceMemberPolling?.original
+              ? formatProgress(
+                  data.sourceMemberPolling.original - data.sourceMemberPolling.remaining,
+                  data.sourceMemberPolling.original
+                )
+              : undefined,
           stage: 'Updating Source Tracking',
           type: 'dynamic-key-value',
         },


### PR DESCRIPTION
### What does this PR do?

Prevent `NaN%` from showing in stage output by not showing source tracking progress is there are no source members. Also added a `if` statement in `formatProgress` to avoid dividing by 0

![Screenshot 2024-08-22 at 12 31 14 PM](https://github.com/user-attachments/assets/29540529-b7ed-4e16-9743-e67321d89ea1)

### What issues does this PR fix or reference?
[skip-validate-pr]