### PR TITLE
fix: 3023 (allow to validate with NoTestRun for later QuickDeploy)

### DIFF
--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -87,7 +87,7 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
     'target-org': Flags.requiredOrg(),
     tests: testsFlag({ helpGroup: testFlags }),
     'test-level': testLevelFlag({
-      options: [TestLevel.RunAllTestsInOrg, TestLevel.RunLocalTests, TestLevel.RunSpecifiedTests],
+      options: [TestLevel.RunAllTestsInOrg, TestLevel.RunLocalTests, TestLevel.RunSpecifiedTests, TestLevel.NoTestRun],
       default: TestLevel.RunLocalTests,
       description: messages.getMessage('flags.test-level.description'),
       summary: messages.getMessage('flags.test-level.summary'),


### PR DESCRIPTION
### What does this PR do?

We need to be able to call project:deploy:validate without running test cases, for example if there are just layouts in the package.xml

Use deploy start --dry-run won't allow the future use of project:deploy:quick

### What issues does this PR fix or reference?

Fixes https://github.com/forcedotcom/cli/issues/3023
