### PR TITLE
feat: build deploy URL using ID

### DIFF
--- a/schemas/project-deploy-cancel.json
+++ b/schemas/project-deploy-cancel.json
@@ -106,6 +106,9 @@
             },
             "stateDetail": {
               "type": "string"
+            },
+            "deployUrl": {
+              "type": "string"
             }
           },
           "required": [
@@ -572,6 +575,9 @@
           "type": "string"
         },
         "stateDetail": {
+          "type": "string"
+        },
+        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/schemas/project-deploy-quick.json
+++ b/schemas/project-deploy-quick.json
@@ -106,6 +106,9 @@
             },
             "stateDetail": {
               "type": "string"
+            },
+            "deployUrl": {
+              "type": "string"
             }
           },
           "required": [
@@ -579,6 +582,9 @@
         },
         "success": {
           "type": "boolean"
+        },
+        "deployUrl": {
+          "type": "string"
         },
         "done": {
           "type": "boolean"

--- a/schemas/project-deploy-report.json
+++ b/schemas/project-deploy-report.json
@@ -106,6 +106,9 @@
             },
             "stateDetail": {
               "type": "string"
+            },
+            "deployUrl": {
+              "type": "string"
             }
           },
           "required": [
@@ -572,6 +575,9 @@
           "type": "string"
         },
         "stateDetail": {
+          "type": "string"
+        },
+        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/schemas/project-deploy-resume.json
+++ b/schemas/project-deploy-resume.json
@@ -106,6 +106,9 @@
             },
             "stateDetail": {
               "type": "string"
+            },
+            "deployUrl": {
+              "type": "string"
             }
           },
           "required": [
@@ -582,6 +585,9 @@
         },
         "done": {
           "type": "boolean"
+        },
+        "deployUrl": {
+          "type": "string"
         }
       },
       "required": ["files", "status"]

--- a/schemas/project-deploy-start.json
+++ b/schemas/project-deploy-start.json
@@ -106,6 +106,9 @@
             },
             "stateDetail": {
               "type": "string"
+            },
+            "deployUrl": {
+              "type": "string"
             }
           },
           "required": [
@@ -572,6 +575,9 @@
           "type": "string"
         },
         "stateDetail": {
+          "type": "string"
+        },
+        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/schemas/project-deploy-validate.json
+++ b/schemas/project-deploy-validate.json
@@ -71,6 +71,9 @@
             "errorStatusCode": {
               "type": "string"
             },
+            "deployUrl": {
+              "type": "string"
+            },
             "ignoreWarnings": {
               "type": "boolean"
             },
@@ -572,6 +575,9 @@
           "type": "string"
         },
         "stateDetail": {
+          "type": "string"
+        },
+        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -10,7 +10,7 @@ import { Messages, Org } from '@salesforce/core';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { MetadataApiDeploy, RequestStatus } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
-import { determineExitCode, resolveApi } from '../../../utils/deploy.js';
+import { determineExitCode, resolveApi, buildDeployUrl } from '../../../utils/deploy.js';
 import { DeployCache } from '../../../utils/deployCache.js';
 import { DEPLOY_STATUS_CODES_DESCRIPTIONS } from '../../../utils/errorCodes.js';
 import { AsyncDeployResultFormatter } from '../../../formatters/asyncDeployResultFormatter.js';
@@ -91,6 +91,8 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
       rest: api === API['REST'],
     });
     this.log(`Deploy ID: ${ansis.bold(deployId)}`);
+    const deployUrl = buildDeployUrl(deployId);
+    this.log(`Deploy URL: ${ansis.bold(deployUrl)}`);
 
     if (flags.async) {
       const asyncFormatter = new AsyncDeployResultFormatter(deployId);

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -76,6 +76,8 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
 
   public static errorCodes = toHelpSection('ERROR CODES', DEPLOY_STATUS_CODES_DESCRIPTIONS);
 
+  private deployUrl?: string;
+
   public async run(): Promise<DeployResultJson> {
     const [{ flags }, cache] = await Promise.all([this.parse(DeployMetadataQuick), DeployCache.create()]);
 
@@ -91,13 +93,13 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
       rest: api === API['REST'],
     });
     this.log(`Deploy ID: ${ansis.bold(deployId)}`);
-    const deployUrl = buildDeployUrl(deployId);
-    this.log(`Deploy URL: ${ansis.bold(deployUrl)}`);
+    this.deployUrl = buildDeployUrl(deployId);
+    this.log(`Deploy URL: ${ansis.bold(this.deployUrl)}`);
 
     if (flags.async) {
       const asyncFormatter = new AsyncDeployResultFormatter(deployId);
       if (!this.jsonEnabled()) asyncFormatter.display();
-      return asyncFormatter.getJson();
+      return this.mixinUrlMeta(await asyncFormatter.getJson());
     }
 
     const mdapiDeploy = new MetadataApiDeploy({
@@ -125,7 +127,7 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
       this.log(messages.getMessage('error.QuickDeployFailure', [deployId, result.response.status]));
     }
 
-    return formatter.getJson();
+    return this.mixinUrlMeta(await formatter.getJson());
   }
 
   protected catch(error: SfCommand.Error): Promise<never> {
@@ -139,6 +141,12 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
       });
     }
     return super.catch(error);
+  }
+  private mixinUrlMeta(json: DeployResultJson): DeployResultJson {
+    if (this.deployUrl) {
+      json.deployUrl = this.deployUrl;
+    }
+    return json;
   }
 }
 

--- a/src/commands/project/deploy/quick.ts
+++ b/src/commands/project/deploy/quick.ts
@@ -93,7 +93,7 @@ export default class DeployMetadataQuick extends SfCommand<DeployResultJson> {
       rest: api === API['REST'],
     });
     this.log(`Deploy ID: ${ansis.bold(deployId)}`);
-    this.deployUrl = buildDeployUrl(deployId);
+    this.deployUrl = buildDeployUrl(flags['target-org'], deployId);
     this.log(`Deploy URL: ${ansis.bold(this.deployUrl)}`);
 
     if (flags.async) {

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -13,7 +13,13 @@ import { Duration } from '@salesforce/kit';
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter.js';
 import { DeployProgress } from '../../../utils/progressBar.js';
 import { API, DeployResultJson } from '../../../utils/types.js';
-import { buildComponentSet, determineExitCode, executeDeploy, isNotResumable } from '../../../utils/deploy.js';
+import {
+  buildComponentSet,
+  determineExitCode,
+  executeDeploy,
+  isNotResumable,
+  buildDeployUrl,
+} from '../../../utils/deploy.js';
 import { DeployCache } from '../../../utils/deployCache.js';
 import { DEPLOY_STATUS_CODES_DESCRIPTIONS } from '../../../utils/errorCodes.js';
 import { coverageFormattersFlag } from '../../../utils/flags.js';
@@ -125,6 +131,8 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
       );
 
       this.log(`Deploy ID: ${ansis.bold(jobId)}`);
+      const deployUrl = buildDeployUrl(jobId);
+      this.log(`Deploy URL: ${ansis.bold(deployUrl)}`);
       new DeployProgress(deploy, this.jsonEnabled()).start();
       result = await deploy.pollStatus(500, wait.seconds);
 

--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -13,13 +13,7 @@ import { Duration } from '@salesforce/kit';
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter.js';
 import { DeployProgress } from '../../../utils/progressBar.js';
 import { API, DeployResultJson } from '../../../utils/types.js';
-import {
-  buildComponentSet,
-  determineExitCode,
-  executeDeploy,
-  isNotResumable,
-  buildDeployUrl,
-} from '../../../utils/deploy.js';
+import { buildComponentSet, determineExitCode, executeDeploy, isNotResumable } from '../../../utils/deploy.js';
 import { DeployCache } from '../../../utils/deployCache.js';
 import { DEPLOY_STATUS_CODES_DESCRIPTIONS } from '../../../utils/errorCodes.js';
 import { coverageFormattersFlag } from '../../../utils/flags.js';
@@ -85,8 +79,6 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
 
   public static errorCodes = toHelpSection('ERROR CODES', DEPLOY_STATUS_CODES_DESCRIPTIONS);
 
-  private deployUrl?: string;
-
   public async run(): Promise<DeployResultJson> {
     const [{ flags }, cache] = await Promise.all([this.parse(DeployMetadataResume), DeployCache.create()]);
     const jobId = cache.resolveLatest(flags['use-most-recent'], flags['job-id'], true);
@@ -133,8 +125,6 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
       );
 
       this.log(`Deploy ID: ${ansis.bold(jobId)}`);
-      this.deployUrl = buildDeployUrl(jobId);
-      this.log(`Deploy URL: ${ansis.bold(this.deployUrl)}`);
       new DeployProgress(deploy, this.jsonEnabled()).start();
       result = await deploy.pollStatus(500, wait.seconds);
 
@@ -156,12 +146,6 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
 
     if (!this.jsonEnabled()) formatter.display();
 
-    return this.mixinUrlMeta(await formatter.getJson());
-  }
-  private mixinUrlMeta(json: DeployResultJson): DeployResultJson {
-    if (this.deployUrl) {
-      json.deployUrl = this.deployUrl;
-    }
-    return json;
+    return formatter.getJson();
   }
 }

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -247,7 +247,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       throw new SfError('The deploy id is not available.');
     }
     this.log(`Deploy ID: ${ansis.bold(deploy.id)}`);
-    this.deployUrl = buildDeployUrl(deploy.id);
+    this.deployUrl = buildDeployUrl(flags['target-org'], deploy.id);
     this.log(`Deploy URL: ${ansis.bold(this.deployUrl)}`);
 
     if (flags.async) {

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -15,7 +15,7 @@ import { AsyncDeployResultFormatter } from '../../../formatters/asyncDeployResul
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter.js';
 import { AsyncDeployResultJson, DeployResultJson, TestLevel } from '../../../utils/types.js';
 import { DeployProgress } from '../../../utils/progressBar.js';
-import { executeDeploy, resolveApi, validateTests, determineExitCode } from '../../../utils/deploy.js';
+import { executeDeploy, resolveApi, validateTests, determineExitCode, buildDeployUrl } from '../../../utils/deploy.js';
 import { DeployCache } from '../../../utils/deployCache.js';
 import { DEPLOY_STATUS_CODES_DESCRIPTIONS } from '../../../utils/errorCodes.js';
 import { ConfigVars } from '../../../configMeta.js';
@@ -246,6 +246,8 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       throw new SfError('The deploy id is not available.');
     }
     this.log(`Deploy ID: ${ansis.bold(deploy.id)}`);
+    const deployUrl = buildDeployUrl(deploy.id);
+    this.log(`Deploy URL: ${ansis.bold(deployUrl)}`);
 
     if (flags.async) {
       if (flags['coverage-formatters']) {

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -179,6 +179,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
 
   private zipSize?: number;
   private zipFileCount?: number;
+  private deployUrl?: string;
 
   public async run(): Promise<DeployResultJson> {
     const { flags } = await this.parse(DeployMetadata);
@@ -246,8 +247,8 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
       throw new SfError('The deploy id is not available.');
     }
     this.log(`Deploy ID: ${ansis.bold(deploy.id)}`);
-    const deployUrl = buildDeployUrl(deploy.id);
-    this.log(`Deploy URL: ${ansis.bold(deployUrl)}`);
+    this.deployUrl = buildDeployUrl(deploy.id);
+    this.log(`Deploy URL: ${ansis.bold(this.deployUrl)}`);
 
     if (flags.async) {
       if (flags['coverage-formatters']) {
@@ -305,6 +306,9 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
     }
     if (this.zipFileCount) {
       json.zipFileCount = this.zipFileCount;
+    }
+    if (this.deployUrl) {
+      json.deployUrl = this.deployUrl;
     }
     return json;
   }

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -198,7 +198,7 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
       throw new SfError('The deploy id is not available.');
     }
     this.log(`Deploy ID: ${ansis.bold(deploy.id)}`);
-    this.deployUrl = buildDeployUrl(deploy.id);
+    this.deployUrl = buildDeployUrl(flags['target-org'], deploy.id);
     this.log(`Deploy URL: ${ansis.bold(this.deployUrl)}`);
 
     if (flags.async) {

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -15,7 +15,7 @@ import { AsyncDeployResultFormatter } from '../../../formatters/asyncDeployResul
 import { DeployResultFormatter } from '../../../formatters/deployResultFormatter.js';
 import { DeployProgress } from '../../../utils/progressBar.js';
 import { DeployResultJson, TestLevel } from '../../../utils/types.js';
-import { executeDeploy, resolveApi, determineExitCode, validateTests } from '../../../utils/deploy.js';
+import { executeDeploy, resolveApi, determineExitCode, validateTests, buildDeployUrl } from '../../../utils/deploy.js';
 import { DEPLOY_STATUS_CODES_DESCRIPTIONS } from '../../../utils/errorCodes.js';
 import { ConfigVars } from '../../../configMeta.js';
 import { coverageFormattersFlag, fileOrDirFlag, testLevelFlag, testsFlag } from '../../../utils/flags.js';
@@ -196,6 +196,8 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
       throw new SfError('The deploy id is not available.');
     }
     this.log(`Deploy ID: ${ansis.bold(deploy.id)}`);
+    const deployUrl = buildDeployUrl(deploy.id);
+    this.log(`Deploy URL: ${ansis.bold(deployUrl)}`);
 
     if (flags.async) {
       const asyncFormatter = new AsyncDeployResultFormatter(deploy.id);

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ConfigAggregator, Messages, Org, OrgConfigProperties, SfError, SfProject } from '@salesforce/core';
+import { ConfigAggregator, Messages, Org, SfError, SfProject } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { Nullable } from '@salesforce/ts-types';
 import {
@@ -242,7 +242,7 @@ const buildApiOptions = (opts: Partial<DeployOptions>): MetadataApiDeployOptions
   purgeOnDelete: opts['purge-on-delete'] ?? false,
 });
 
-export function buildDeployUrl(deployId: string): string {
-  const orgInstanceUrl = OrgConfigProperties.ORG_INSTANCE_URL;
+export function buildDeployUrl(org: Org, deployId: string): string {
+  const orgInstanceUrl = String(org.getField(Org.Fields.INSTANCE_URL));
   return `${orgInstanceUrl}/lightning/setup/DeployStatus/page?address=%2Fchangemgmt%2FmonitorDeploymentsDetails.apexp%3FasyncId%3D${deployId}%26retURL%3D%252Fchangemgmt%252FmonitorDeployment.apexp`;
 }

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ConfigAggregator, Messages, Org, SfError, SfProject } from '@salesforce/core';
+import { ConfigAggregator, Messages, Org, OrgConfigProperties, SfError, SfProject } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { Nullable } from '@salesforce/ts-types';
 import {
@@ -241,3 +241,8 @@ const buildApiOptions = (opts: Partial<DeployOptions>): MetadataApiDeployOptions
   ...(opts['test-level'] ? { testLevel: opts['test-level'] } : {}),
   purgeOnDelete: opts['purge-on-delete'] ?? false,
 });
+
+export function buildDeployUrl(deployId: string): string {
+  const orgInstanceUrl = OrgConfigProperties.ORG_INSTANCE_URL;
+  return `${orgInstanceUrl}/lightning/setup/DeployStatus/page?address=%2Fchangemgmt%2FmonitorDeploymentsDetails.apexp%3FasyncId%3D${deployId}%26retURL%3D%252Fchangemgmt%252FmonitorDeployment.apexp`;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -45,6 +45,7 @@ export type AsyncDeployResultJson = Omit<Partial<MetadataApiDeployStatus>, 'stat
   files: FileResponse[];
   zipSize?: number;
   zipFileCount?: number;
+  deployUrl?: string;
 };
 
 type ConvertEntry = {
@@ -79,6 +80,7 @@ export type DeployResultJson =
       replacements?: Record<string, string[]>;
       zipSize?: number;
       zipFileCount?: number;
+      deployUrl?: string;
     })
   | AsyncDeployResultJson;
 


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to add Deploy URLs after the Deploy ID is printed in all project deploy commands. 

This is my first contribution period to a Salesforce repo, please let me know if I'm doing something wrong. This seemed like a simple update to add based on the `OrgConfigProperties` class from sfdx-core, but I'm not sure if there's something I missed when I'm trying to use this to get the org instance URL.

This will print the Classic URL, but we can update this to Lightning if that's preferred.

I know in at least GitLab CI/CD, just printing a valid URL in the pipeline log as I do in my Python script will create a clickable link. But if there's an explicit method in Typescript that can build a clickable link in all cases, I'm open to suggestion.

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/discussions/2531

I currently have a Python function which reads through the CLI logs and prints this URL manually. But I think this would be small but useful feature to add to the CLI in order to easily track the deployment directly in the org (in the event there is a Metadata API request failure, etc.). 