### PR TITLE
Replace force source status

### DIFF
--- a/test/nuts/tracking/basics.nut.ts
+++ b/test/nuts/tracking/basics.nut.ts
@@ -129,7 +129,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       }).jsonOutput?.result;
       expect(
         deployResult?.filter((r) => r.type === 'Profile').filter(filterIgnored),
-        JSON.stringify(result)
+        JSON.stringify(deployResult)
       ).to.have.length(0);
 
       const retrieveResult = execCmd<StatusResult[]>('project retrieve preview --json', {
@@ -138,7 +138,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       }).jsonOutput?.result;
       expect(
         retrieveResult?.filter((r) => r.type === 'Profile').filter(filterIgnored),
-        JSON.stringify(result)
+        JSON.stringify(retrieveResult)
       ).to.have.length(0);
     });
 

--- a/test/nuts/tracking/basics.nut.ts
+++ b/test/nuts/tracking/basics.nut.ts
@@ -48,7 +48,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
 
   describe('basic status and pull', () => {
     it('detects the initial metadata status', () => {
-      const result = execCmd<StatusResult[]>('force:source:status --json', {
+      const result = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -85,13 +85,13 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       expect(files.every(isSdrSuccess), JSON.stringify(files.filter(isSdrFailure))).to.equal(true);
     });
     it('sees no local changes (all were committed from push), but profile updated in remote', () => {
-      const localResult = execCmd<StatusResult[]>('force:source:status --json --local', {
+      const localResult = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
       expect(localResult?.filter(filterIgnored)).to.deep.equal([]);
 
-      const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
+      const remoteResult = execCmd<StatusResult[]>('project retrieve preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -105,7 +105,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       expect(response?.toDeploy).to.be.an.instanceof(Array).with.lengthOf(0);
     });
     it('sf sees no remote changes (all were committed from push) except Profile', () => {
-      const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
+      const remoteResult = execCmd<StatusResult[]>('project retrieve preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -123,13 +123,23 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
     });
 
     it('sees no local or remote changes', () => {
-      const result = execCmd<StatusResult[]>('force:source:status --json', {
+      const deployResult = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
-      expect(result?.filter((r) => r.type === 'Profile').filter(filterIgnored), JSON.stringify(result)).to.have.length(
-        0
-      );
+      expect(
+        deployResult?.filter((r) => r.type === 'Profile').filter(filterIgnored),
+        JSON.stringify(result)
+      ).to.have.length(0);
+
+      const retrieveResult = execCmd<StatusResult[]>('project retrieve preview --json', {
+        ensureExitCode: 0,
+        cli: 'sf',
+      }).jsonOutput?.result;
+      expect(
+        retrieveResult?.filter((r) => r.type === 'Profile').filter(filterIgnored),
+        JSON.stringify(result)
+      ).to.have.length(0);
     });
 
     it('sf no local changes', () => {
@@ -152,7 +162,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
         fs.promises.unlink(path.join(classDir, 'TestOrderController.cls')),
         fs.promises.unlink(path.join(classDir, 'TestOrderController.cls-meta.xml')),
       ]);
-      const result = execCmd<StatusResult[]>('force:source:status --json --local', {
+      const result = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -197,7 +207,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       ]);
     });
     it('does not see any change in remote status', () => {
-      const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
+      const result = execCmd<StatusResult[]>('project retrieve preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -223,7 +233,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       expect(result, JSON.stringify(result)).to.be.an.instanceof(Array).with.length(2);
     });
     it('sees no local changes', () => {
-      const result = execCmd<StatusResult[]>('force:source:status --json --local', {
+      const result = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -243,7 +253,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
     it('should throw an err when attempting to pull from a non scratch-org', () => {
       const hubUsername = session.hubOrg.username;
       assert(hubUsername, 'hubUsername should be defined');
-      const failure = execCmd(`force:source:status -u ${hubUsername} --remote --json`, {
+      const failure = execCmd(`project retrieve preview -u ${hubUsername} --json`, {
         ensureExitCode: 1,
         cli: 'sf',
       }).jsonOutput as unknown as { name: string };
@@ -282,7 +292,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       });
       describe('classes that failed to deploy are still in local status', () => {
         it('sees no local changes', () => {
-          const result = execCmd<StatusResult[]>('force:source:status --json --local', {
+          const result = execCmd<StatusResult[]>('project deploy preview --json', {
             ensureExitCode: 0,
             cli: 'sf',
           }).jsonOutput?.result;

--- a/test/nuts/tracking/conflicts.nut.ts
+++ b/test/nuts/tracking/conflicts.nut.ts
@@ -70,7 +70,7 @@ describe('conflict detection and resolution', () => {
         description: 'modified',
       },
     });
-    const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
+    const result = execCmd<StatusResult[]>('project retrieve preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     }).jsonOutput?.result;
@@ -94,7 +94,7 @@ describe('conflict detection and resolution', () => {
     );
   });
   it('can see the conflict in status', () => {
-    const result = execCmd<StatusResult[]>('force:source:status --json', {
+    const result = execCmd<StatusResult[]>('project deploy preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     }).jsonOutput?.result.filter((app) => app.type === 'CustomApplication');

--- a/test/nuts/tracking/deleteResetTracking.nut.ts
+++ b/test/nuts/tracking/deleteResetTracking.nut.ts
@@ -64,7 +64,7 @@ describe('reset and clear tracking', () => {
 
   describe('clearing tracking', () => {
     it('runs status to start tracking', () => {
-      const result = execCmd('force:source:status --json', {
+      const result = execCmd('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -110,7 +110,7 @@ describe('reset and clear tracking', () => {
         }
       });
       // gets tracking files from server
-      execCmd('force:source:status --json --remote', { ensureExitCode: 0, cli: 'sf' });
+      execCmd('project retrieve preview --json', { ensureExitCode: 0, cli: 'sf' });
       const revisions = await getRevisionsAsArray();
       const revisionFile = JSON.parse(
         await fs.promises.readFile(path.join(trackingFileFolder, 'maxRevision.json'), 'utf8')

--- a/test/nuts/tracking/forceIgnore.nut.ts
+++ b/test/nuts/tracking/forceIgnore.nut.ts
@@ -70,7 +70,7 @@ describe('forceignore changes', () => {
     });
 
     it('shows the file in status as ignored', () => {
-      const output = execCmd<StatusResult>('force:source:status --json', {
+      const output = execCmd<StatusResult>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -156,7 +156,7 @@ describe('forceignore changes', () => {
 
     it('source:status recognizes change', () => {
       // gets file into source tracking
-      const statusOutput = execCmd<StatusResult[]>('force:source:status --json --remote', {
+      const statusOutput = execCmd<StatusResult[]>('project retrieve preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;

--- a/test/nuts/tracking/lwc.nut.ts
+++ b/test/nuts/tracking/lwc.nut.ts
@@ -56,7 +56,7 @@ describe('lwc', () => {
       cssPathAbsolute,
       (await fs.promises.readFile(cssPathAbsolute, 'utf-8')).replace('absolute', 'relative')
     );
-    const result = execCmd<StatusResult[]>('force:source:status --json', {
+    const result = execCmd<StatusResult[]>('project deploy preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     }).jsonOutput?.result;
@@ -86,7 +86,7 @@ describe('lwc', () => {
   });
 
   it('sfdx sees no local changes', () => {
-    const result = execCmd<StatusResult[]>('force:source:status --json', {
+    const result = execCmd<StatusResult[]>('project deploy preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     })
@@ -106,7 +106,7 @@ describe('lwc', () => {
 
   it("deleting an lwc sub-component should show the sub-component as 'Deleted'", async () => {
     await fs.promises.rm(cssPathAbsolute);
-    const result = execCmd<StatusResult[]>('force:source:status --json', {
+    const result = execCmd<StatusResult[]>('project deploy preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     })
@@ -138,7 +138,7 @@ describe('lwc', () => {
   });
 
   it('sees no local changes', () => {
-    const result = execCmd<StatusResult[]>('force:source:status --json', {
+    const result = execCmd<StatusResult[]>('project deploy preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     })
@@ -169,7 +169,7 @@ describe('lwc', () => {
       dependentLWCPath,
       (await fs.promises.readFile(dependentLWCPath, 'utf-8')).replace(/<c-hero.*hero-details>/s, '')
     );
-    const result = execCmd<StatusResult[]>('force:source:status --json', {
+    const result = execCmd<StatusResult[]>('project deploy preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     }).jsonOutput?.result.filter((r) => r.origin === 'Local');
@@ -193,7 +193,7 @@ describe('lwc', () => {
   });
 
   it('sees no local changes', () => {
-    const result = execCmd<StatusResult[]>('force:source:status --json', {
+    const result = execCmd<StatusResult[]>('project deploy preview --json', {
       ensureExitCode: 0,
       cli: 'sf',
     })

--- a/test/nuts/tracking/remoteChanges.nut.ts
+++ b/test/nuts/tracking/remoteChanges.nut.ts
@@ -66,7 +66,7 @@ describe('remote changes', () => {
     });
 
     it('sees no local changes (all were committed from deploy)', () => {
-      const localResult = execCmd<StatusResult[]>('force:source:status --json --local', {
+      const localResult = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -107,7 +107,7 @@ describe('remote changes', () => {
       ).to.equal(true);
     });
     it('sfdx can see the delete in status', () => {
-      const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
+      const result = execCmd<StatusResult[]>('project retrieve preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -125,7 +125,7 @@ describe('remote changes', () => {
       expect(result?.toDelete, JSON.stringify(result)).to.have.length(1);
     });
     it('sfdx does not see any change in local status', () => {
-      const result = execCmd<StatusResult[]>('force:source:status --json --local', {
+      const result = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -162,13 +162,13 @@ describe('remote changes', () => {
       ).to.equal(false);
     });
     it('sees correct local and remote status', () => {
-      const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
+      const remoteResult = execCmd<StatusResult[]>('project retrieve preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
       expect(remoteResult?.filter((r) => r.state.includes('Remote Deleted'))).to.deep.equal([]);
 
-      const localStatus = execCmd<StatusResult[]>('force:source:status --json --local', {
+      const localStatus = execCmd<StatusResult[]>('project deploy preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -202,7 +202,7 @@ describe('remote changes', () => {
       }
     });
     it('can see the add in status', () => {
-      const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
+      const result = execCmd<StatusResult[]>('project retrieve preview --json', {
         ensureExitCode: 0,
         cli: 'sf',
       }).jsonOutput?.result;
@@ -230,7 +230,7 @@ describe('remote changes', () => {
     });
     describe('check status', () => {
       it('sfdx sees correct remote status', () => {
-        const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
+        const remoteResult = execCmd<StatusResult[]>('project retrieve preview --json', {
           ensureExitCode: 0,
           cli: 'sf',
         }).jsonOutput?.result;
@@ -240,7 +240,7 @@ describe('remote changes', () => {
         ).deep.equal([]);
       });
       it('sfdx sees correct local status', () => {
-        const localStatus = execCmd<StatusResult[]>('force:source:status --json --local', {
+        const localStatus = execCmd<StatusResult[]>('project deploy preview --json', {
           ensureExitCode: 0,
           cli: 'sf',
         }).jsonOutput?.result;


### PR DESCRIPTION
### What does this PR do?
Replaces deprecated `force:source:status` commands

### What issues does this PR fix or reference?
[@W-17062306@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-17062306)