### PR TITLE
test: use regex when asserting table output

### DIFF
--- a/test/nuts/tracking/forceIgnore.nut.ts
+++ b/test/nuts/tracking/forceIgnore.nut.ts
@@ -193,9 +193,9 @@ describe('forceignore changes', () => {
       }).shellOutput.stdout;
 
       expect(output).to.include('Will Deploy [1] files.');
-      expect(output).to.include('ApexClass   UnIgnoreTest');
+      expect(output).to.match(/ApexClass\s+UnIgnoreTest/);
       expect(output).to.not.include("These files won't deploy because they're ignored by your .forceignore file.");
-      expect(output).to.not.include('ApexClass   IgnoreTest');
+      expect(output).to.not.match(/ApexClass\s+IgnoreTest/);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Use regex when asserting table output in nuts so that slight changes in table spacing doesn't cause failures

### What issues does this PR fix or reference?
[skip-validate-pr]