### PR TITLE
fix: repurposes 'error' column, to show the metadata type

### DIFF
--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -310,13 +310,13 @@ export class DeployResultFormatter extends TestResultsFormatter implements Forma
     ux.log();
     ux.table({
       data: sortBy(failures, ['problemType', 'fullName', 'lineNumber', 'columnNumber', 'error']).map((f) => ({
-        problemType: f.problemType,
+        type: f.type,
         fullName: f.fullName,
         error: f.error,
         loc: f.lineNumber ? `${f.lineNumber}:${f.columnNumber ?? ''}` : '',
       })),
       columns: [
-        { key: 'problemType', name: 'Type' },
+        { key: 'type', name: 'Type' },
         { key: 'fullName', name: 'Name' },
         { key: 'error', name: 'Problem' },
         { key: 'loc', name: 'Line:Column' },

--- a/test/utils/output.test.ts
+++ b/test/utils/output.test.ts
@@ -38,14 +38,14 @@ describe('deployResultFormatter', () => {
       expect(tableStub.firstCall.args[0]).to.deep.equal({
         data: [
           {
-            problemType: 'Error',
+            type: 'ApexClass',
             fullName: 'ProductController',
             error: 'This component has some problems',
             loc: '27:18',
           },
         ],
         columns: [
-          { key: 'problemType', name: 'Type' },
+          { key: 'type', name: 'Type' },
           { key: 'fullName', name: 'Name' },
           { key: 'error', name: 'Problem' },
           { key: 'loc', name: 'Line:Column' },
@@ -106,21 +106,21 @@ describe('deployResultFormatter', () => {
       expect(tableStub.firstCall.args[0]).to.deep.equal({
         data: [
           {
-            problemType: 'Error',
+            type: '',
             fullName: 'Create_property',
             error:
               "An object 'Create_property' of type Flow was named in package.xml, but was not found in zipped directory",
             loc: '',
           },
           {
-            problemType: 'Error',
+            type: 'ApexClass',
             fullName: 'ProductController',
             error: 'This component has some problems',
             loc: '27:18',
           },
         ],
         columns: [
-          { key: 'problemType', name: 'Type' },
+          { key: 'type', name: 'Type' },
           { key: 'fullName', name: 'Name' },
           { key: 'error', name: 'Problem' },
           { key: 'loc', name: 'Line:Column' },


### PR DESCRIPTION
### What does this PR do?
```bash
┌───────┬─────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────┬─────────────┐
│ Type  │ Name                        │ Problem                                                                          │ Line:Column │
├───────┼─────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────┼─────────────┤
│ Error │ Broker__c-Broker Layout     │ Invalid field:Address__c in related list:Property__c.Broker__c                   │             │
│ Error │ Create_property             │ field integrity exception: unknown (The field "Address__c" for the object 
```
rather than displaying every error in the error table as an error, show what metadata type has the error, 

```bash
┌──────────────────────────┬─────────────────────────────┬───────────────────────────────────────────────────────────────┬─────────────┐
│ Type                     │ Name                        │ Problem                                                       │ Line:Column │
├──────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────────────────┼─────────────┤
│ Layout                   │ Broker__c-Broker Layout     │ Invalid field:Address__c in related                           │             │
│                          │                             │ list:Property__c.Broker__c                                    │             │
│ Flow                     │ Create_property             │ field integrity exception: unknown (The field "Address__c"    │         
```

this helps users understand which component, exactly, is causing the error
### What issues does this PR fix or reference?
@W-17227008@
https://github.com/forcedotcom/cli/issues/3110