### PR TITLE
fix: remove ref to `SF_USE_PROGRESS_BAR` env var

### DIFF
--- a/src/commands/project/deploy/resume.ts
+++ b/src/commands/project/deploy/resume.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { EnvironmentVariable, Messages, Org, SfError } from '@salesforce/core';
+import { Messages, Org, SfError } from '@salesforce/core';
 import { SfCommand, toHelpSection, Flags } from '@salesforce/sf-plugins-core';
 import { DeployResult, MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
@@ -80,7 +80,7 @@ export default class DeployMetadataResume extends SfCommand<DeployResultJson> {
     }),
   };
 
-  public static envVariablesSection = toHelpSection('ENVIRONMENT VARIABLES', EnvironmentVariable.SF_USE_PROGRESS_BAR);
+  public static envVariablesSection = toHelpSection('ENVIRONMENT VARIABLES');
 
   public static errorCodes = toHelpSection('ERROR CODES', DEPLOY_STATUS_CODES_DESCRIPTIONS);
 

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -166,11 +166,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
     ConfigVars.ORG_METADATA_REST_DEPLOY
   );
 
-  public static envVariablesSection = toHelpSection(
-    'ENVIRONMENT VARIABLES',
-    EnvironmentVariable.SF_TARGET_ORG,
-    EnvironmentVariable.SF_USE_PROGRESS_BAR
-  );
+  public static envVariablesSection = toHelpSection('ENVIRONMENT VARIABLES', EnvironmentVariable.SF_TARGET_ORG);
 
   public static errorCodes = toHelpSection('ERROR CODES', DEPLOY_STATUS_CODES_DESCRIPTIONS);
 

--- a/src/commands/project/deploy/validate.ts
+++ b/src/commands/project/deploy/validate.ts
@@ -147,11 +147,7 @@ export default class DeployMetadataValidate extends SfCommand<DeployResultJson> 
     ConfigVars.ORG_METADATA_REST_DEPLOY
   );
 
-  public static envVariablesSection = toHelpSection(
-    'ENVIRONMENT VARIABLES',
-    EnvironmentVariable.SF_TARGET_ORG,
-    EnvironmentVariable.SF_USE_PROGRESS_BAR
-  );
+  public static envVariablesSection = toHelpSection('ENVIRONMENT VARIABLES', EnvironmentVariable.SF_TARGET_ORG);
 
   public static errorCodes = toHelpSection('ERROR CODES', DEPLOY_STATUS_CODES_DESCRIPTIONS);
 

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -141,11 +141,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
     OrgConfigProperties.TARGET_ORG,
     OrgConfigProperties.ORG_API_VERSION
   );
-  public static envVariablesSection = toHelpSection(
-    'ENVIRONMENT VARIABLES',
-    EnvironmentVariable.SF_TARGET_ORG,
-    EnvironmentVariable.SF_USE_PROGRESS_BAR
-  );
+  public static envVariablesSection = toHelpSection('ENVIRONMENT VARIABLES', EnvironmentVariable.SF_TARGET_ORG);
 
   protected retrieveResult!: RetrieveResult;
   protected ms:


### PR DESCRIPTION
### What does this PR do?

we removed support for `SF_USE_PROGRESS_BAR`.
TODO:
mention new oclif/mso env vars

### What issues does this PR fix or reference?
ref: https://github.com/forcedotcom/cli/issues/3123
[skip-validate-wi]