### PR TITLE
fix: no ENOENT when nothing retrieved to specific directory

### DIFF
--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -354,6 +354,11 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
       );
       return directories;
     }
+    // If we retrieved only a package.xml, just return.
+    if (this.retrieveResult.getFileResponses().length < 2) {
+      return;
+    }
+
     // getFileResponses fails once the files have been moved, calculate where they're moved to, and then move them
     this.retrieveResult.getFileResponses().forEach((fileResponse) => {
       fileResponse.filePath = fileResponse.filePath?.replace(join('main', 'default'), '');

--- a/test/nuts/retrieve/metadata.nut.ts
+++ b/test/nuts/retrieve/metadata.nut.ts
@@ -83,6 +83,20 @@ describe('retrieve metadata NUTs', () => {
       await testkit.expect.filesToBeRetrieved(['myOutput/classes/*', 'myOutput/aura/**/*']);
     });
 
+    it('should warn when nothing retrieved into output-dir and not throw ENOENT', async () => {
+      const result = await testkit.retrieve({ args: '--metadata ApexClass:NonExistant --output-dir myOutput' });
+      expect(result?.status).to.equal(0);
+      const retrieveResult = result?.result as unknown as RetrieveResultJson;
+      expect(retrieveResult.success).to.equal(true);
+      expect(retrieveResult.fileProperties).to.be.an('array').with.lengthOf(1);
+      expect(retrieveResult.messages).to.deep.equal([
+        {
+          fileName: 'unpackaged/package.xml',
+          problem: "Entity of type 'ApexClass' named 'NonExistant' cannot be found",
+        },
+      ]);
+    });
+
     it('should retrieve ApexClasses from wildcard match', async () => {
       const response = await testkit.retrieve({ args: '--metadata "ApexClass:Test*"' });
       expect(response?.status).to.equal(0);


### PR DESCRIPTION
### What does this PR do?
When no metadata was retrieved and the `--output-dir` flag was used, fixes the ENOENT error that was thrown.

### What issues does this PR fix or reference?
@W-17355528@