### PR TITLE
fix: add warning when nothing to delete

### DIFF
--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -189,7 +189,9 @@ export class Source extends SfCommand<DeleteSourceJson> {
       this.log('No results found');
       if (this.componentSet.forceIgnoredPaths?.size) {
         // we have nothing in the CS, and something forceignored, let the user know they're trying to delete a forceignored file
-        this.warn('Attempting to delete metadata that conflicts with a .forceignore entry');
+        const ignoredComponentPaths = Array.from(this.componentSet.forceIgnoredPaths).toString();
+        this.warn(`Attempting to delete metadata that conflicts with a .forceignore entry: ${ignoredComponentPaths}
+Update the .forceignore file and try again.`);
       }
     }
 

--- a/src/commands/project/delete/source.ts
+++ b/src/commands/project/delete/source.ts
@@ -8,7 +8,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-
 import { Interfaces } from '@oclif/core';
 import { Lifecycle, Messages, Org, SfError } from '@salesforce/core';
 import {
@@ -188,7 +187,10 @@ export class Source extends SfCommand<DeleteSourceJson> {
       // if we didn't find any components to delete, let the user know and exit
       this.styledHeader(tableHeader('Deleted Source'));
       this.log('No results found');
-      return;
+      if (this.componentSet.forceIgnoredPaths?.size) {
+        // we have nothing in the CS, and something forceignored, let the user know they're trying to delete a forceignored file
+        this.warn('Attempting to delete metadata that conflicts with a .forceignore entry');
+      }
     }
 
     // create a new ComponentSet and mark everything for deletion
@@ -285,7 +287,7 @@ export class Source extends SfCommand<DeleteSourceJson> {
    */
   protected async resolveSuccess(): Promise<void> {
     // if deploy failed restore the stashed files if they exist
-    if (this.deployResult?.response?.status !== RequestStatus.Succeeded) {
+    if (this.deployResult && this.deployResult.response?.status !== RequestStatus.Succeeded) {
       process.exitCode = 1;
       await Promise.all(
         this.mixedDeployDelete.delete.map(async (file) => {

--- a/test/commands/delete/source.test.ts
+++ b/test/commands/delete/source.test.ts
@@ -15,7 +15,7 @@ import {
   SourceComponent,
 } from '@salesforce/source-deploy-retrieve';
 import { Lifecycle, SfProject } from '@salesforce/core';
-import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
+import { fromStub, spyMethod, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { Config } from '@oclif/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { SfCommand } from '@salesforce/sf-plugins-core';
@@ -203,6 +203,17 @@ describe('project delete source', () => {
     ensureHookArgs();
     // deleting the component and its xml
     expect(rmStub.callCount).to.equal(2);
+  });
+
+  it('should warn if everything is forceignored', async () => {
+    buildComponentSetStub.restore();
+    const warnSpy = spyMethod($$.SANDBOX, SfCommand.prototype, 'warn');
+    buildComponentSetStub = stubMethod($$.SANDBOX, ComponentSetBuilder, 'build').resolves({
+      forceIgnoredPaths: new Set<string>('myPath'),
+      toArray: () => [],
+    });
+    await runDeleteCmd(['--metadata', 'ApexClass:MyClass', '--json', '-r']);
+    expect(warnSpy.calledOnce).to.be.true;
   });
 
   it('should pass along metadata', async () => {


### PR DESCRIPTION
### What does this PR do?
if you `project delete source` on something that's forceignored, you can have a bad time
this makes you have less of a bad time, prints a warning

### What issues does this PR fix or reference?
@W-17013213@