### PR TITLE
fix: prevent duplicate MSO after table

### DIFF
--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -293,10 +293,11 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
   }
 
   protected catch(error: Error | SfError): Promise<never> {
+    this.stages?.update({ status: 'Failed' });
+    this.stages?.error();
+
     if (error instanceof SourceConflictError && error.data) {
       if (!this.jsonEnabled()) {
-        this.stages?.update({ status: 'Failed' });
-        this.stages?.error();
         writeConflictTable(error.data);
         // set the message and add plugin-specific actions
         return super.catch({

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -279,6 +279,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
 
     const result = await deploy.pollStatus({ timeout: flags.wait });
     process.exitCode = determineExitCode(result);
+    this.stages.stop();
     const formatter = new DeployResultFormatter(result, flags);
 
     if (!this.jsonEnabled()) {


### PR DESCRIPTION
### What does this PR do?

Sometimes MSO would receive the final update from SDR _after_ the table was written to the terminal. This changes ensures that MSO is always stopped before the table is rendered.

### What issues does this PR fix or reference?
[skip-validate-pr]