### PR TITLE
fix: always render apex test reports W-17758238

### DIFF
--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -280,7 +280,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
     const result = await deploy.pollStatus({ timeout: flags.wait });
     process.exitCode = determineExitCode(result);
     this.stages.stop();
-    const formatter = new DeployResultFormatter(result, flags);
+    const formatter = new DeployResultFormatter(result, flags, undefined, true);
 
     if (!this.jsonEnabled()) {
       formatter.display();

--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -73,7 +73,8 @@ export class DeployResultFormatter extends TestResultsFormatter implements Forma
       wait: Duration | number;
     }>,
     /** add extra synthetic fileResponses not in the mdapiResponse  */
-    protected extraDeletes: FileResponseSuccess[] = []
+    protected extraDeletes: FileResponseSuccess[] = [],
+    skipVerboseTestReportOnCI = false
   ) {
     super(result, flags);
     this.absoluteFiles = (this.result.getFileResponses() ?? []).sort(fileResponseSortFn);
@@ -83,6 +84,7 @@ export class DeployResultFormatter extends TestResultsFormatter implements Forma
     this.resultsDir = this.flags['results-dir'] ?? 'coverage';
     this.coverageOptions = getCoverageFormattersOptions(this.flags['coverage-formatters']);
     this.junit = this.flags.junit;
+    this.skipVerboseTestReportOnCI = skipVerboseTestReportOnCI;
   }
 
   public async getJson(): Promise<DeployResultJson> {


### PR DESCRIPTION
### What does this PR do?
Updates test formatters to always print apex test reports unless the caller doesn't want to.
This fixes a regression introduced [in this PR](https://github.com/salesforcecli/plugin-deploy-retrieve/pull/1215) where commands were missing the `Test Failures` report on CI runs of commands like `project deploy report`.

### What issues does this PR fix or reference?
@W-17758238@