### PR TITLE
fix: handle single file components move to output-dir W-17615754

### DIFF
--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -21,6 +21,7 @@ import {
   MetadataApiRetrieveStatus,
   RegistryAccess,
   RequestStatus,
+  ComponentStatus,
 } from '@salesforce/source-deploy-retrieve';
 import { SfCommand, toHelpSection, Flags, Ux } from '@salesforce/sf-plugins-core';
 import { getString } from '@salesforce/ts-types';
@@ -354,8 +355,12 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
       );
       return directories;
     }
-    // If we retrieved only a package.xml, just return.
-    if (this.retrieveResult.getFileResponses().length < 1) {
+
+    // skip file move if all retrieves failed to avoid ENOENT err (no such file or directory).
+    if (
+      this.retrieveResult.getFileResponses().length ===
+      this.retrieveResult.getFileResponses().filter((c) => c.state === ComponentStatus.Failed).length
+    ) {
       return;
     }
 

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -355,7 +355,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
       return directories;
     }
     // If we retrieved only a package.xml, just return.
-    if (this.retrieveResult.getFileResponses().length < 2) {
+    if (this.retrieveResult.getFileResponses().length < 1) {
       return;
     }
 

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -6,7 +6,7 @@
  */
 
 import { rm } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 import * as fs from 'node:fs';
 
 import { MultiStageOutput } from '@oclif/multi-stage-output';
@@ -366,7 +366,7 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
 
     // getFileResponses fails once the files have been moved, calculate where they're moved to, and then move them
     this.retrieveResult.getFileResponses().forEach((fileResponse) => {
-      fileResponse.filePath = fileResponse.filePath?.replace(join('main', 'default'), '');
+      fileResponse.filePath = fileResponse.filePath?.replace(join('main', 'default', sep), '');
     });
     // move contents of 'main/default' to 'retrievetargetdir'
     await promisesQueue([join(resolvedTargetDir, 'main', 'default')], mv, 5, true);


### PR DESCRIPTION
### What does this PR do?
Fixes `project retrieve start --output-dir lala` writing single-file components to `lala/main/default` instead of `lala`.
### How does `--output-dir` works?
1. SDR does the retrieve, there's no local components to merge with so it writes them to `<output-dir>/main/default`
2. `project retrieve start` checks if SDR retrieved files, if so then moves them from `<output-dir>/main/default` to `<output-dir` and nukes `main/default`.

The bug was in step 2, the command was skipping the file move if less than 2 files were retrieved (leaving single-file components like `GlobalValueSet` in `<output-dir>/main/default`.

### Testing
1. clone dreamhouse and create a scratch org
2. create a globalvalueset in the org: `sf org open -p lightning/setup/Picklists/home` 
3. retrieve it to `lala`, see it being written to `lala/main/default`: `sf project retrieve start -m GlobalValueSet --output-dir lala`
4. retrieve an apex class, it has 2 files (cls and meta xml) and will trigger the file move (including globalvalueset): `sf project retrieve start -m ApexClass:PagedResult --output-dir lala`

The component/file response check was introduced here to fix a ENOENT err:
https://github.com/salesforcecli/plugin-deploy-retrieve/pull/1236

the change in this PR updates the check to skip the file move if all retrieves failed so it shouldn't cause a regression and also fixes the `ENOENT` error on +1 failures:
![Screenshot 2025-02-12 at 12 23 26](https://github.com/user-attachments/assets/10f89e4f-aee9-46ed-9852-ae5c28bbc325)


### What issues does this PR fix or reference?
@W-17615754@
https://github.com/forcedotcom/cli/issues/3177