### PR TITLE
fix: convert URL to path before doing path ops

### DIFF
--- a/src/utils/convertBehavior.ts
+++ b/src/utils/convertBehavior.ts
@@ -24,8 +24,11 @@ import { isString } from '@salesforce/ts-types';
 export type ComponentSetAndPackageDirPath = { packageDirPath: string; cs: ComponentSet };
 
 // TODO: there could be a cleaner way to read this
-const PRESET_DIR = fileURLToPath(
-  join(import.meta.resolve('@salesforce/source-deploy-retrieve'), '..', 'registry', 'presets')
+const PRESET_DIR = join(
+  fileURLToPath(import.meta.resolve('@salesforce/source-deploy-retrieve')),
+  '..',
+  'registry',
+  'presets'
 );
 export const PRESETS_PROP = 'sourceBehaviorOptions';
 export const PRESET_CHOICES = [...presetMap.keys()];


### PR DESCRIPTION
### What does this PR do?
Convert URL returned from `import.meta.resolve` to a path before doing path operations.
The current behavior was broken after a vuln. fix and wasn't officially supported: https://github.com/nodejs/node/issues/56853#issuecomment-2627842534

https://github.com/advisories/GHSA-37v4-cwgp-x353

### What issues does this PR fix or reference?
@W-17737287@