### PR TITLE
fix: for W-19029417 - fix finalzing MDAPI state W-19029417

### DIFF
--- a/messages/metadata.transfer.md
+++ b/messages/metadata.transfer.md
@@ -25,3 +25,7 @@ Failed
 # Canceling
 
 Canceling
+
+# Finalizing
+
+Finalizing


### PR DESCRIPTION
### What does this PR do?
fixes an error thrown by our messages parser when looking for a new message

'Finalizing' state message present
no errors
needs a 258 OrgFarm org on greater than CL 53818728
### What issues does this PR fix or reference?
@W-19029417@