### PR TITLE
fix: bump SDR

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@salesforce/kit": "^3.2.3",
     "@salesforce/plugin-info": "^3.4.67",
     "@salesforce/sf-plugins-core": "^12.2.2",
-    "@salesforce/source-deploy-retrieve": "^12.21.1",
+    "@salesforce/source-deploy-retrieve": "^12.22.0",
     "@salesforce/source-tracking": "^7.4.1",
     "@salesforce/ts-types": "^2.0.12",
     "ansis": "^3.17.0",

--- a/schemas/project-delete-source.json
+++ b/schemas/project-delete-source.json
@@ -156,7 +156,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "DeployDetails": {
       "type": "object",

--- a/schemas/project-deploy-cancel.json
+++ b/schemas/project-deploy-cancel.json
@@ -29,6 +29,9 @@
             "zipFileCount": {
               "type": "number"
             },
+            "deployUrl": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
             },
@@ -105,9 +108,6 @@
               "type": "string"
             },
             "stateDetail": {
-              "type": "string"
-            },
-            "deployUrl": {
               "type": "string"
             }
           },
@@ -204,7 +204,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "DeployDetails": {
       "type": "object",
@@ -511,6 +520,9 @@
         "zipFileCount": {
           "type": "number"
         },
+        "deployUrl": {
+          "type": "string"
+        },
         "canceledBy": {
           "type": "string"
         },
@@ -575,9 +587,6 @@
           "type": "string"
         },
         "stateDetail": {
-          "type": "string"
-        },
-        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/schemas/project-deploy-quick.json
+++ b/schemas/project-deploy-quick.json
@@ -29,6 +29,9 @@
             "zipFileCount": {
               "type": "number"
             },
+            "deployUrl": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
             },
@@ -105,9 +108,6 @@
               "type": "string"
             },
             "stateDetail": {
-              "type": "string"
-            },
-            "deployUrl": {
               "type": "string"
             }
           },
@@ -204,7 +204,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "DeployDetails": {
       "type": "object",
@@ -511,6 +520,9 @@
         "zipFileCount": {
           "type": "number"
         },
+        "deployUrl": {
+          "type": "string"
+        },
         "canceledBy": {
           "type": "string"
         },
@@ -582,9 +594,6 @@
         },
         "success": {
           "type": "boolean"
-        },
-        "deployUrl": {
-          "type": "string"
         },
         "done": {
           "type": "boolean"

--- a/schemas/project-deploy-report.json
+++ b/schemas/project-deploy-report.json
@@ -29,6 +29,9 @@
             "zipFileCount": {
               "type": "number"
             },
+            "deployUrl": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
             },
@@ -105,9 +108,6 @@
               "type": "string"
             },
             "stateDetail": {
-              "type": "string"
-            },
-            "deployUrl": {
               "type": "string"
             }
           },
@@ -204,7 +204,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "DeployDetails": {
       "type": "object",
@@ -511,6 +520,9 @@
         "zipFileCount": {
           "type": "number"
         },
+        "deployUrl": {
+          "type": "string"
+        },
         "canceledBy": {
           "type": "string"
         },
@@ -575,9 +587,6 @@
           "type": "string"
         },
         "stateDetail": {
-          "type": "string"
-        },
-        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/schemas/project-deploy-resume.json
+++ b/schemas/project-deploy-resume.json
@@ -29,6 +29,9 @@
             "zipFileCount": {
               "type": "number"
             },
+            "deployUrl": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
             },
@@ -105,9 +108,6 @@
               "type": "string"
             },
             "stateDetail": {
-              "type": "string"
-            },
-            "deployUrl": {
               "type": "string"
             }
           },
@@ -204,7 +204,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "DeployDetails": {
       "type": "object",
@@ -511,6 +520,9 @@
         "zipFileCount": {
           "type": "number"
         },
+        "deployUrl": {
+          "type": "string"
+        },
         "canceledBy": {
           "type": "string"
         },
@@ -585,9 +597,6 @@
         },
         "done": {
           "type": "boolean"
-        },
-        "deployUrl": {
-          "type": "string"
         }
       },
       "required": ["files", "status"]

--- a/schemas/project-deploy-start.json
+++ b/schemas/project-deploy-start.json
@@ -29,6 +29,9 @@
             "zipFileCount": {
               "type": "number"
             },
+            "deployUrl": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
             },
@@ -105,9 +108,6 @@
               "type": "string"
             },
             "stateDetail": {
-              "type": "string"
-            },
-            "deployUrl": {
               "type": "string"
             }
           },
@@ -204,7 +204,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "DeployDetails": {
       "type": "object",
@@ -511,6 +520,9 @@
         "zipFileCount": {
           "type": "number"
         },
+        "deployUrl": {
+          "type": "string"
+        },
         "canceledBy": {
           "type": "string"
         },
@@ -575,9 +587,6 @@
           "type": "string"
         },
         "stateDetail": {
-          "type": "string"
-        },
-        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/schemas/project-deploy-validate.json
+++ b/schemas/project-deploy-validate.json
@@ -29,6 +29,9 @@
             "zipFileCount": {
               "type": "number"
             },
+            "deployUrl": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
             },
@@ -69,9 +72,6 @@
               "type": "string"
             },
             "errorStatusCode": {
-              "type": "string"
-            },
-            "deployUrl": {
               "type": "string"
             },
             "ignoreWarnings": {
@@ -204,7 +204,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "DeployDetails": {
       "type": "object",
@@ -511,6 +520,9 @@
         "zipFileCount": {
           "type": "number"
         },
+        "deployUrl": {
+          "type": "string"
+        },
         "canceledBy": {
           "type": "string"
         },
@@ -575,9 +587,6 @@
           "type": "string"
         },
         "stateDetail": {
-          "type": "string"
-        },
-        "deployUrl": {
           "type": "string"
         },
         "id": {

--- a/schemas/project-retrieve-start.json
+++ b/schemas/project-retrieve-start.json
@@ -192,7 +192,16 @@
     },
     "RequestStatus": {
       "type": "string",
-      "enum": ["Pending", "InProgress", "Succeeded", "SucceededPartial", "Failed", "Canceling", "Canceled"]
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "SucceededPartial",
+        "Failed",
+        "Canceling",
+        "Canceled",
+        "Finalizing"
+      ]
     },
     "RetrieveMessage": {
       "type": "object",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,7 +1729,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.12.0", "@salesforce/core@^8.14.0", "@salesforce/core@^8.15.0", "@salesforce/core@^8.17.0", "@salesforce/core@^8.18.1", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0":
+"@salesforce/core@^8.14.0", "@salesforce/core@^8.15.0", "@salesforce/core@^8.17.0", "@salesforce/core@^8.18.1", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0":
   version "8.18.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.18.1.tgz#4a790f9479339f45e42799d9ef7a1428d49b6ba1"
   integrity sha512-RkG9Ye5TdsIQz4KLUHvDpVjbrTeeRmw5KUJIHRyMGAOjKB8wr2jvgXyZm7GD0epIW5ILsyKQQWWOa1uqsfVycA==
@@ -1873,12 +1873,12 @@
     cli-progress "^3.12.0"
     terminal-link "^3.0.0"
 
-"@salesforce/source-deploy-retrieve@^12.20.1", "@salesforce/source-deploy-retrieve@^12.21.0", "@salesforce/source-deploy-retrieve@^12.21.1":
-  version "12.21.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.21.1.tgz#081ea10b86b1af3c222d9dea3ac3774bdb477954"
-  integrity sha512-VC6sAaLH04z1znJh7f8ftlUTDEzzUFzpaau8kIVjZW7Iq4xSnRORmxlh941C2KSTPRR454ZbnxuWC5czcn5Bcg==
+"@salesforce/source-deploy-retrieve@^12.20.1", "@salesforce/source-deploy-retrieve@^12.21.0", "@salesforce/source-deploy-retrieve@^12.22.0":
+  version "12.22.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.22.0.tgz#4993bff177ac7fe421af93e30dabb8a57b23a1de"
+  integrity sha512-tfBgeiQ7uypXogv//S0QIU05fstKHryNGj5I4p2FhlP7Lv93G27ACxyaK2yGtRsHEqNx5yMz81vbyLoqhPmLTQ==
   dependencies:
-    "@salesforce/core" "^8.12.0"
+    "@salesforce/core" "^8.18.1"
     "@salesforce/kit" "^3.2.3"
     "@salesforce/ts-types" "^2.0.12"
     "@salesforce/types" "^1.3.0"
@@ -2140,22 +2140,7 @@
     "@smithy/util-middleware" "^4.0.4"
     tslib "^2.6.2"
 
-"@smithy/core@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.6.0.tgz#be02f2a4a56ba83d37298454a0bddc89cbad510b"
-  integrity sha512-Pgvfb+TQ4wUNLyHzvgCP4aYZMh16y7GcfF59oirRHcgGgkH1e/s9C0nv/v3WP+Quymyr5je71HeFQCwh+44XLg==
-  dependencies:
-    "@smithy/middleware-serde" "^4.0.8"
-    "@smithy/protocol-http" "^5.1.2"
-    "@smithy/types" "^4.3.1"
-    "@smithy/util-base64" "^4.0.0"
-    "@smithy/util-body-length-browser" "^4.0.0"
-    "@smithy/util-middleware" "^4.0.4"
-    "@smithy/util-stream" "^4.2.2"
-    "@smithy/util-utf8" "^4.0.0"
-    tslib "^2.6.2"
-
-"@smithy/core@^3.7.0", "@smithy/core@^3.7.1":
+"@smithy/core@^3.6.0", "@smithy/core@^3.7.0", "@smithy/core@^3.7.1":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.7.1.tgz#7f47fc1ec93f20b686d007a7d667a02de8b86219"
   integrity sha512-ExRCsHnXFtBPnM7MkfKBPcBBdHw1h/QS/cbNw4ho95qnyNHvnpmGbR39MIAv9KggTr5qSPxRSEL+hRXlyGyGQw==
@@ -2226,18 +2211,7 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/fetch-http-handler@^5.0.4":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz#c68601b4676787e049b5d464d5f4b825dbb44013"
-  integrity sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==
-  dependencies:
-    "@smithy/protocol-http" "^5.1.2"
-    "@smithy/querystring-builder" "^4.0.4"
-    "@smithy/types" "^4.3.1"
-    "@smithy/util-base64" "^4.0.0"
-    tslib "^2.6.2"
-
-"@smithy/fetch-http-handler@^5.1.0":
+"@smithy/fetch-http-handler@^5.0.4", "@smithy/fetch-http-handler@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz#387abd9ec6c8ff0af33b268c0f6ccb289c1b1563"
   integrity sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==
@@ -2317,21 +2291,7 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/middleware-endpoint@^4.1.13":
-  version "4.1.13"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.13.tgz#7d5b5f8f61600270bd8c59aabf311c99b9127aba"
-  integrity sha512-xg3EHV/Q5ZdAO5b0UiIMj3RIOCobuS40pBBODguUDVdko6YK6QIzCVRrHTogVuEKglBWqWenRnZ71iZnLL3ZAQ==
-  dependencies:
-    "@smithy/core" "^3.6.0"
-    "@smithy/middleware-serde" "^4.0.8"
-    "@smithy/node-config-provider" "^4.1.3"
-    "@smithy/shared-ini-file-loader" "^4.0.4"
-    "@smithy/types" "^4.3.1"
-    "@smithy/url-parser" "^4.0.4"
-    "@smithy/util-middleware" "^4.0.4"
-    tslib "^2.6.2"
-
-"@smithy/middleware-endpoint@^4.1.15", "@smithy/middleware-endpoint@^4.1.16":
+"@smithy/middleware-endpoint@^4.1.13", "@smithy/middleware-endpoint@^4.1.15", "@smithy/middleware-endpoint@^4.1.16":
   version "4.1.16"
   resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.16.tgz#d0fea3683659289974a87afb089e5f38575f96c0"
   integrity sha512-plpa50PIGLqzMR2ANKAw2yOW5YKS626KYKqae3atwucbz4Ve4uQ9K9BEZxDLIFmCu7hKLcrq2zmj4a+PfmUV5w==
@@ -2345,22 +2305,7 @@
     "@smithy/util-middleware" "^4.0.4"
     tslib "^2.6.2"
 
-"@smithy/middleware-retry@^4.1.14":
-  version "4.1.14"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.14.tgz#53ce619463a1ce4b95025aaafdf51369ef893196"
-  integrity sha512-eoXaLlDGpKvdmvt+YBfRXE7HmIEtFF+DJCbTPwuLunP0YUnrydl+C4tS+vEM0+nyxXrX3PSUFqC+lP1+EHB1Tw==
-  dependencies:
-    "@smithy/node-config-provider" "^4.1.3"
-    "@smithy/protocol-http" "^5.1.2"
-    "@smithy/service-error-classification" "^4.0.6"
-    "@smithy/smithy-client" "^4.4.5"
-    "@smithy/types" "^4.3.1"
-    "@smithy/util-middleware" "^4.0.4"
-    "@smithy/util-retry" "^4.0.6"
-    tslib "^2.6.2"
-    uuid "^9.0.1"
-
-"@smithy/middleware-retry@^4.1.16":
+"@smithy/middleware-retry@^4.1.14", "@smithy/middleware-retry@^4.1.16":
   version "4.1.17"
   resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.17.tgz#5a7aa2547918422e3a8747520900c2fd26a43328"
   integrity sha512-gsCimeG6BApj0SBecwa1Be+Z+JOJe46iy3B3m3A8jKJHf7eIihP76Is4LwLrbJ1ygoS7Vg73lfqzejmLOrazUA==
@@ -2402,18 +2347,7 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/node-http-handler@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz#a022da499ba3af4b6b4c815104fde973c0eccc40"
-  integrity sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==
-  dependencies:
-    "@smithy/abort-controller" "^4.0.4"
-    "@smithy/protocol-http" "^5.1.2"
-    "@smithy/querystring-builder" "^4.0.4"
-    "@smithy/types" "^4.3.1"
-    tslib "^2.6.2"
-
-"@smithy/node-http-handler@^4.1.0":
+"@smithy/node-http-handler@^4.0.6", "@smithy/node-http-handler@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz#6b528cd0da0c35755b34afba207b7db972b0eb92"
   integrity sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==
@@ -2486,20 +2420,7 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/smithy-client@^4.4.5":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.4.5.tgz#1c736618f3c4910880cc6862a5826348c1b70d5d"
-  integrity sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==
-  dependencies:
-    "@smithy/core" "^3.6.0"
-    "@smithy/middleware-endpoint" "^4.1.13"
-    "@smithy/middleware-stack" "^4.0.4"
-    "@smithy/protocol-http" "^5.1.2"
-    "@smithy/types" "^4.3.1"
-    "@smithy/util-stream" "^4.2.2"
-    tslib "^2.6.2"
-
-"@smithy/smithy-client@^4.4.7", "@smithy/smithy-client@^4.4.8":
+"@smithy/smithy-client@^4.4.5", "@smithy/smithy-client@^4.4.7", "@smithy/smithy-client@^4.4.8":
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.4.8.tgz#91b562a4f60db92c2533a720a091e98557117ab6"
   integrity sha512-pcW691/lx7V54gE+dDGC26nxz8nrvnvRSCJaIYD6XLPpOInEZeKdV/SpSux+wqeQ4Ine7LJQu8uxMvobTIBK0w==
@@ -2574,18 +2495,7 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/util-defaults-mode-browser@^4.0.21":
-  version "4.0.21"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.21.tgz#47895e42d64060d2a7f803a443fd160d0a329d83"
-  integrity sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==
-  dependencies:
-    "@smithy/property-provider" "^4.0.4"
-    "@smithy/smithy-client" "^4.4.5"
-    "@smithy/types" "^4.3.1"
-    bowser "^2.11.0"
-    tslib "^2.6.2"
-
-"@smithy/util-defaults-mode-browser@^4.0.23":
+"@smithy/util-defaults-mode-browser@^4.0.21", "@smithy/util-defaults-mode-browser@^4.0.23":
   version "4.0.24"
   resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.24.tgz#36e2ebd191cffa4799c2474d1d4e793264067fa9"
   integrity sha512-UkQNgaQ+bidw1MgdgPO1z1k95W/v8Ej/5o/T/Is8PiVUYPspl/ZxV6WO/8DrzZQu5ULnmpB9CDdMSRwgRc21AA==
@@ -2596,20 +2506,7 @@
     bowser "^2.11.0"
     tslib "^2.6.2"
 
-"@smithy/util-defaults-mode-node@^4.0.21":
-  version "4.0.21"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.21.tgz#4682143fbfb0a4c6e08a6151f13af97018e6950e"
-  integrity sha512-/F34zkoU0GzpUgLJydHY8Rxu9lBn8xQC/s/0M0U9lLBkYbA1htaAFjWYJzpzsbXPuri5D1H8gjp2jBum05qBrA==
-  dependencies:
-    "@smithy/config-resolver" "^4.1.4"
-    "@smithy/credential-provider-imds" "^4.0.6"
-    "@smithy/node-config-provider" "^4.1.3"
-    "@smithy/property-provider" "^4.0.4"
-    "@smithy/smithy-client" "^4.4.5"
-    "@smithy/types" "^4.3.1"
-    tslib "^2.6.2"
-
-"@smithy/util-defaults-mode-node@^4.0.23":
+"@smithy/util-defaults-mode-node@^4.0.21", "@smithy/util-defaults-mode-node@^4.0.23":
   version "4.0.24"
   resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.24.tgz#3b9382bbffcc5c211e582ea6164c630ad994816f"
   integrity sha512-phvGi/15Z4MpuQibTLOYIumvLdXb+XIJu8TA55voGgboln85jytA3wiD7CkUE8SNcWqkkb+uptZKPiuFouX/7g==
@@ -2655,21 +2552,7 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
-"@smithy/util-stream@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.2.2.tgz#beeb1edf690db9b7d7983f46ca4fb66e22253608"
-  integrity sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==
-  dependencies:
-    "@smithy/fetch-http-handler" "^5.0.4"
-    "@smithy/node-http-handler" "^4.0.6"
-    "@smithy/types" "^4.3.1"
-    "@smithy/util-base64" "^4.0.0"
-    "@smithy/util-buffer-from" "^4.0.0"
-    "@smithy/util-hex-encoding" "^4.0.0"
-    "@smithy/util-utf8" "^4.0.0"
-    tslib "^2.6.2"
-
-"@smithy/util-stream@^4.2.3":
+"@smithy/util-stream@^4.2.2", "@smithy/util-stream@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.2.3.tgz#7980fb94dbee96301b0b2610de8ae1700c7daab1"
   integrity sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==


### PR DESCRIPTION
### What does this PR do?
Bump SDR to get new Rule type and other fixes, see SDR changelog since v12.21.1:
https://github.com/forcedotcom/source-deploy-retrieve/blob/main/CHANGELOG.md

Command schemas changed because the metadata API added a new supported state:
https://github.com/forcedotcom/source-deploy-retrieve/pull/1585

### What issues does this PR fix or reference?
[skip-validate-pr]