### PR TITLE
Add a warning in PDR-W-18681384

### DIFF
--- a/messages/deploy.metadata.md
+++ b/messages/deploy.metadata.md
@@ -257,3 +257,8 @@ The `pushPackageDirectoriesSequentially` property is not respected by this comma
 # apiVersionMsgDetailed
 
 %s %s metadata to %s using the v%s %s API.
+
+# noSourceTrackingWarning
+
+Starting in December 2025, this command will require source tracking support.
+Production orgs and other non-tracking orgs will no longer be supported without explicit metadata specification.

--- a/messages/retrieve.start.md
+++ b/messages/retrieve.start.md
@@ -199,3 +199,8 @@ This command expects the org to support source tracking. If it doesn't, you must
 - Use the `--source-dir`, `--manifest` or `--package-name` flags to retrieve metadata in source format.
 
 - Use the `--target-metadata-dir` flag to retrieve metadata in metadata format to a directory.
+
+# noSourceTrackingWarning
+
+Starting in December 2025, this command will require source tracking support.
+Production orgs and other non-tracking orgs will no longer be supported without explicit metadata specification.

--- a/src/commands/project/deploy/start.ts
+++ b/src/commands/project/deploy/start.ts
@@ -234,6 +234,7 @@ export default class DeployMetadata extends SfCommand<DeployResultJson> {
         ...flags,
         'target-org': username,
         api,
+        warnCallback: this.warn.bind(this),
       },
       project
     );

--- a/src/commands/project/retrieve/start.ts
+++ b/src/commands/project/retrieve/start.ts
@@ -176,6 +176,19 @@ export default class RetrieveMetadata extends SfCommand<RetrieveResultJson> {
   // eslint-disable-next-line complexity
   public async run(): Promise<RetrieveResultJson> {
     const { flags } = await this.parse(RetrieveMetadata);
+
+    // Add warning for non-source-tracking orgs when using default behavior
+    const isChanges =
+      !flags['source-dir'] &&
+      !flags['manifest'] &&
+      !flags['metadata'] &&
+      !flags['target-metadata-dir'] &&
+      !flags['package-name']?.length;
+
+    if (isChanges && !(await flags['target-org'].tracksSource())) {
+      this.warn(messages.getMessage('noSourceTrackingWarning'));
+    }
+
     let resolvedTargetDir: string | undefined;
     if (flags['output-dir']) {
       resolvedTargetDir = resolve(flags['output-dir']);
@@ -518,6 +531,7 @@ const buildRetrieveOptions = async (
   output: string | undefined
 ): Promise<RetrieveSetOptions> => {
   const apiVersion = await resolveApiVersion(flags);
+
   return {
     usernameOrConnection: flags['target-org'].getUsername() ?? flags['target-org'].getConnection(flags['api-version']),
     merge: true,

--- a/src/utils/deploy.ts
+++ b/src/utils/deploy.ts
@@ -53,10 +53,11 @@ export type DeployOptions = {
   'pre-destructive-changes'?: string;
   'post-destructive-changes'?: string;
   'purge-on-delete'?: boolean;
+  warnCallback?: (message: string) => void;
 };
 
 /** Manifest is expected.  You cannot pass metadata and source-dir array--use those to get a manifest */
-export type CachedOptions = Omit<DeployOptions, 'wait' | 'metadata' | 'source-dir'> & {
+export type CachedOptions = Omit<DeployOptions, 'wait' | 'metadata' | 'source-dir' | 'warnCallback'> & {
   wait: number;
   /** whether the user passed in anything for metadata-dir (could be a folder, could be a zip) */
   isMdapi: boolean;
@@ -150,6 +151,10 @@ export async function executeDeploy(
       subscribeSDREvents: !opts['dry-run'] || !(await org.tracksSource()),
       ignoreConflicts: opts['ignore-conflicts'],
     });
+
+    if (!(await org.tracksSource()) && opts.warnCallback) {
+      opts.warnCallback(deployMessages.getMessage('noSourceTrackingWarning'));
+    }
     registry = stl.registry;
 
     componentSet = await buildComponentSet(opts, stl);

--- a/test/nuts/retrieve/noTracking.nut.ts
+++ b/test/nuts/retrieve/noTracking.nut.ts
@@ -55,7 +55,7 @@ describe('retrieve mdapi format without project', () => {
     });
 
     expect(result.jsonOutput?.name).to.equal('noSourceTracking');
-    expect(result.jsonOutput?.message).to.include('does not support source tracking');
+    expect(result.jsonOutput?.message).to.include('Unable to track changes in your source files');
   });
 
   after(async () => {

--- a/test/nuts/retrieve/noTracking.nut.ts
+++ b/test/nuts/retrieve/noTracking.nut.ts
@@ -49,6 +49,15 @@ describe('retrieve mdapi format without project', () => {
     expect(result?.files).to.not.be.empty;
   });
 
+  it('should fail when retrieving changes from a non-tracking org', () => {
+    const result = execCmd<RetrieveResultJson>(`project:retrieve:start -o ${session.hubOrg.username} --json`, {
+      ensureExitCode: 1,
+    });
+
+    expect(result.jsonOutput?.name).to.equal('noSourceTracking');
+    expect(result.jsonOutput?.message).to.include('does not support source tracking');
+  });
+
   after(async () => {
     await session?.clean();
   });


### PR DESCRIPTION
### What does this PR do?
Add a warning, using the project deploy/retrieve start without any md flag should be fail in the future.
-with scratch org without source tracking
### What issues does this PR fix or reference?
@W-18681384@