### PR TITLE
fix: add missing throw before messages.createError() calls

### DIFF
--- a/src/commands/project/deploy/cancel.ts
+++ b/src/commands/project/deploy/cancel.ts
@@ -85,7 +85,7 @@ export default class DeployMetadataCancel extends SfCommand<DeployResultJson> {
         deployOpts.status
       )
     ) {
-      messages.createError('error.CannotCancelDeployPre', [jobId, deployOpts.status]);
+      throw messages.createError('error.CannotCancelDeployPre', [jobId, deployOpts.status]);
     }
 
     if (flags.async) {

--- a/src/utils/convertBehavior.ts
+++ b/src/utils/convertBehavior.ts
@@ -60,7 +60,7 @@ export const getPackageDirectoriesForPreset = async (
     )
   ).filter(componentSetIsNonEmpty);
   if (output.length === 0) {
-    messages.createError('error.noTargetTypes', [preset]);
+    throw messages.createError('error.noTargetTypes', [preset]);
   }
 
   return output;


### PR DESCRIPTION
## Summary

Two locations call `messages.createError()` but never `throw` the result, silently swallowing errors and allowing execution to continue past conditions that should halt.

### `src/commands/project/deploy/cancel.ts:88`

```typescript
// before
messages.createError('error.CannotCancelDeployPre', [jobId, deployOpts.status]);

// after
throw messages.createError('error.CannotCancelDeployPre', [jobId, deployOpts.status]);
```

When a deployment is already in a terminal state (`Canceled`, `Failed`, `Succeeded`, `SucceededPartial`), this guard is supposed to prevent the cancel attempt. Without `throw`, the error is created and discarded, and the cancel proceeds on an already-finished job.

### `src/utils/convertBehavior.ts:63`

```typescript
// before
messages.createError('error.noTargetTypes', [preset]);

// after
throw messages.createError('error.noTargetTypes', [preset]);
```

When `getPackageDirectoriesForPreset` finds no matching component sets for the given preset, it should surface a `noTargetTypes` error. Without `throw`, the error is dropped and the function silently returns an empty array.

Both cases follow the same `throw messages.createError(...)` pattern used consistently everywhere else in the codebase.

## Test plan
- [ ] `yarn build` passes
- [ ] Existing tests pass
- [ ] Manual test: cancel a completed deployment — should now surface the expected error instead of attempting to cancel