### PR TITLE
test: update manifest NUT for new platform permission set @W-23071487@

### DIFF
--- a/test/nuts/manifest/manifestCreate.nut.ts
+++ b/test/nuts/manifest/manifestCreate.nut.ts
@@ -161,6 +161,7 @@ describe('project generate manifest', () => {
         '    </types>\n' +
         '    <types>\n' +
         '        <members>dreamhouse</members>\n' +
+        '        <members>sfdcInternalInt__sfdc_nc_constraints_engine_deploy</members>\n' +
         '        <members>sfdcInternalInt__sfdc_scrt2</members>\n' +
         '        <name>PermissionSet</name>\n' +
         '    </types>\n' +


### PR DESCRIPTION
## Summary
- Scratch orgs now include `sfdcInternalInt__sfdc_nc_constraints_engine_deploy` permission set
- The `manifestCreate` NUT hardcodes expected manifest contents and fails when the platform adds new internal components
- Added the new permission set to the expected string

## Work Item
@W-23071487@: Fix manifestCreate NUT: add new platform permission set to expected output

## Test plan
- [x] NUT `project generate manifest > from org > should produce a manifest from an include list of metadata in an org` passes